### PR TITLE
Firewall-update

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -308,7 +308,8 @@ FunctionsToExport = @(
     'Get-NsxServiceGroup',
     'Get-NsxServiceGroupMember',
     'Remove-NsxServiceGroup',
-    'Get-NsxLoadBalancerStats'
+    'Get-NsxLoadBalancerStats',
+    'Get-NsxFirewallSavedConfiguration'
 )
 
 # Cmdlets to export from this module

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -20591,8 +20591,6 @@ function Get-NsxFirewallSavedConfiguration {
 
     Retrieves a Distributed Firewall configuration by ObjectId
 
-    .EXAMPLE
-
     #>
 
     [CmdLetBinding(DefaultParameterSetName="Name")]

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -20575,12 +20575,11 @@ function Get-NsxFirewallSavedConfiguration {
     .DESCRIPTION
     Retireves saved Distributed Firewall configuration.
 
-    A copy of every
-    published configuration is also saved as a draft. A maximum of 100 
-    configurations can be saved at a time. 90 out of these 100 can be auto 
-    saved configurations from a publish operation. When the limit is reached,
-    the oldest configuration that is not marked for preserve is purged to 
-    make way for a new one.
+     A copy of every published configuration is also saved as a draft. A 
+    maximum of 100 configurations can be saved at a time. 90 out of 
+    these 100 can be auto saved configurations from a publish operation. 
+    When the limit is reached,the oldest configuration that is not marked for
+    preserve is purged to make way for a new one.
 
     .EXAMPLE
     Get-NsxFirewallSavedConfiguration

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -20575,7 +20575,7 @@ function Get-NsxFirewallSavedConfiguration {
     .DESCRIPTION
     Retireves saved Distributed Firewall configuration.
 
-     A copy of every published configuration is also saved as a draft. A 
+    A copy of every published configuration is also saved as a draft. A 
     maximum of 100 configurations can be saved at a time. 90 out of 
     these 100 can be auto saved configurations from a publish operation. 
     When the limit is reached,the oldest configuration that is not marked for

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -20566,6 +20566,87 @@ function Remove-NsxFirewallExclusionListMember {
     end {}
 }
 
+function Get-NsxFirewallSavedConfiguration {
+    
+     <#
+    .SYNOPSIS
+    Retrieves saved Distributed Firewall configuration.
+
+    .DESCRIPTION
+    Retireves saved Distributed Firewall configuration.
+
+    A copy of every
+    published configuration is also saved as a draft. A maximum of 100 
+    configurations can be saved at a time. 90 out of these 100 can be auto 
+    saved configurations from a publish operation. When the limit is reached,
+    the oldest configuration that is not marked for preserve is purged to 
+    make way for a new one.
+
+    .EXAMPLE
+    Get-NsxFirewallSavedConfiguration
+
+    Retrieves all saved Distributed Firewall configurations
+
+    .EXAMPLE
+    Get-NsxFirewallSavedConfiguration -ObjectId 403
+
+    Retrieves a Distributed Firewall configuration by ObjectId
+
+    .EXAMPLE
+
+    #>
+
+    [CmdLetBinding(DefaultParameterSetName="Name")]
+    
+    param (
+
+        [Parameter (Mandatory=$false,ParameterSetName="ObjectId")]
+            [string]$ObjectId,
+        [Parameter (Mandatory=$false,Position=1,ParameterSetName="Name")]
+            [string]$Name,
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object.
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+
+    )
+    
+    begin {
+
+    }
+
+    process {
+    
+        if ( -not ($PsBoundParameters.ContainsKey("ObjectId"))) { 
+            #All Sections
+
+            $URI = "/api/4.0/firewall/globalroot-0/drafts"
+            [system.xml.xmldocument]$Response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+            if ($response.SelectSingleNode("child::firewallDrafts")){
+                
+                $Return = $Response
+
+                if ($PsBoundParameters.ContainsKey("Name")){
+                    $Return.firewallDrafts.firewallDraft | ? {$_.name -eq $Name} 
+                }
+                else {
+            
+                    $Return
+                }
+            }
+        }
+        else {
+            
+            $URI = "/api/4.0/firewall/globalroot-0/drafts/$ObjectId"
+            [system.xml.xmldocument]$Response = Invoke-NsxRestMethod -method "get" -uri $URI -connection $connection
+            
+            if ($Response.SelectSingleNode("child::firewallDraft")){
+                $Response.firewallDraft
+            }
+        }
+    }
+    end {}
+}
 
 
 ########

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -20628,7 +20628,7 @@ function Get-NsxFirewallSavedConfiguration {
                 }
                 else {
             
-                    $Return
+                    $Return.firewallDrafts.firewallDraft
                 }
             }
         }


### PR DESCRIPTION
New-NsxFirewallSavedConfiguration command allows reading of the Firewall output. This can be used with name, id, or nothing and return configurations.

* Populated Help
* correctly indented
* xpath validation