### PR TITLE
Fix New-NsxFirewallRule to support service groups

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -20306,7 +20306,7 @@ function New-NsxFirewallRule  {
             [ValidateNotNullOrEmpty()]
             [switch]$NegateDestination,
         [Parameter (Mandatory=$false)]
-            [ValidateScript ({ Validate-Service $_ })]
+            [ValidateScript ({ Validate-ServiceOrServiceGroup $_ })]
             [System.Xml.XmlElement[]]$Service,
         [Parameter (Mandatory=$false)]
             [string]$Comment="",


### PR DESCRIPTION
This replaces the parameter validation script with the 
Validate-ServiceOrServiceGroup function so that service groups are now 
permitted.

Resolves #55
