### PR TITLE
Update PowerNSXInstaller.ps1

### DIFF
--- a/PowerNSXInstaller.ps1
+++ b/PowerNSXInstaller.ps1
@@ -227,7 +227,7 @@ function check-powershell {
                                 install-dotNet45
                             }
                             
-                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64*") {
+                            if ( [System.Environment]::Is64BitOperatingSystem ) {
                                 install-wmf -version 3 -uri $WMF_3_60_64_Download
                             }
                             else {
@@ -243,7 +243,7 @@ function check-powershell {
                                 install-dotNet45
                             }
 
-                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64*") {
+                            if ( [System.Environment]::Is64BitOperatingSystem ) {
                                 install-wmf -version 4 -uri $WMF_3_61_64_Download
                             }
                             else {
@@ -269,7 +269,7 @@ function check-powercli {
 
     #Validate at least PowerCLI 5.5 via uninstall reg key
     Write-Progress -Activity "Installing PowerNSX" -Status "check-powercli" -CurrentOperation "Checking for compatible PowerCLI version"
-    if ((gwmi win32_operatingsystem).osarchitecture -like "64*") { 
+    if ( [System.Environment]::Is64BitOperatingSystem ) { 
         $PowerCli = get-childitem "HKLM:Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall" | % { $_ | get-itemproperty | ? { $_.displayName -match 'PowerCLI' }}
 
     }else {

--- a/PowerNSXInstaller.ps1
+++ b/PowerNSXInstaller.ps1
@@ -227,7 +227,7 @@ function check-powershell {
                                 install-dotNet45
                             }
                             
-                            if ( (gwmi win32_operatingsystem).OSArchitecture -eq "64-Bit") {
+                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64") {
                                 install-wmf -version 3 -uri $WMF_3_60_64_Download
                             }
                             else {
@@ -243,7 +243,7 @@ function check-powershell {
                                 install-dotNet45
                             }
 
-                            if ( (gwmi win32_operatingsystem).OSArchitecture -eq "64-Bit") {
+                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64") {
                                 install-wmf -version 4 -uri $WMF_3_61_64_Download
                             }
                             else {
@@ -269,7 +269,7 @@ function check-powercli {
 
     #Validate at least PowerCLI 5.5 via uninstall reg key
     Write-Progress -Activity "Installing PowerNSX" -Status "check-powercli" -CurrentOperation "Checking for compatible PowerCLI version"
-    if ((gwmi win32_operatingsystem).osarchitecture -eq "64-bit") { 
+    if ((gwmi win32_operatingsystem).osarchitecture -like "64") { 
         $PowerCli = get-childitem "HKLM:Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall" | % { $_ | get-itemproperty | ? { $_.displayName -match 'PowerCLI' }}
 
     }else {

--- a/PowerNSXInstaller.ps1
+++ b/PowerNSXInstaller.ps1
@@ -227,7 +227,7 @@ function check-powershell {
                                 install-dotNet45
                             }
                             
-                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64") {
+                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64*") {
                                 install-wmf -version 3 -uri $WMF_3_60_64_Download
                             }
                             else {
@@ -243,7 +243,7 @@ function check-powershell {
                                 install-dotNet45
                             }
 
-                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64") {
+                            if ( (gwmi win32_operatingsystem).OSArchitecture -like "64*") {
                                 install-wmf -version 4 -uri $WMF_3_61_64_Download
                             }
                             else {
@@ -269,7 +269,7 @@ function check-powercli {
 
     #Validate at least PowerCLI 5.5 via uninstall reg key
     Write-Progress -Activity "Installing PowerNSX" -Status "check-powercli" -CurrentOperation "Checking for compatible PowerCLI version"
-    if ((gwmi win32_operatingsystem).osarchitecture -like "64") { 
+    if ((gwmi win32_operatingsystem).osarchitecture -like "64*") { 
         $PowerCli = get-childitem "HKLM:Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall" | % { $_ | get-itemproperty | ? { $_.displayName -match 'PowerCLI' }}
 
     }else {


### PR DESCRIPTION
In PowerNSXInstaller.ps1
function check-powercli and check-powershelgl: proposed change
if ((gwmi win32_operatingsystem).osarchitecture -eq "64-bit")

with
if ((gwmi win32_operatingsystem).osarchitecture -like "64*”)

Proposed change is to take into account some values in Win8.1 for
instance: “64 bits” in lieu of “64-bit”