### PR TITLE
Implement performance oriented switches

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -19035,6 +19035,8 @@ function New-NsxSecurityGroup   {
             [object[]]$ExcludeMember,
         [Parameter (Mandatory=$false)]
             [string]$scopeId="globalroot-0",
+        [Parameter (Mandatory=$false)]
+            [switch]$ReturnObjectIdOnly=$false,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -19088,7 +19090,12 @@ function New-NsxSecurityGroup   {
         $URI = "/api/2.0/services/securitygroup/bulk/$scopeId"
         $response = invoke-nsxwebrequest -method "post" -uri $URI -body $body -connection $connection
 
-        Get-NsxSecuritygroup -objectId $response.content -connection $connection
+        if ( $ReturnObjectIdOnly) {
+            $response.content
+        }
+        else {
+            Get-NsxSecuritygroup -objectId $response.content -connection $connection
+        }
     }
     end {}
 }
@@ -19923,6 +19930,8 @@ function New-NsxIpSet  {
             [string]$IPAddresses,
         [Parameter (Mandatory=$false)]
             [string]$scopeId="globalroot-0",
+        [Parameter (Mandatory=$false)]
+            [switch]$ReturnObjectIdOnly=$false,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -19948,7 +19957,12 @@ function New-NsxIpSet  {
         $URI = "/api/2.0/services/ipset/$scopeId"
         $response = invoke-nsxwebrequest -method "post" -uri $URI -body $body -connection $connection
 
-        Get-NsxIPSet -objectid $response.content -connection $connection
+        if ( $ReturnObjectIdOnly) {
+            $response.content
+        }
+        else {
+            Get-NsxIPSet -objectid $response.content -connection $connection
+        }
     }
     end {}
 }
@@ -20458,17 +20472,17 @@ function New-NsxService  {
               "LOOP", "MS_RPC_TCP", "MS_RPC_UDP", "NBDG_BROADCAST",
               "NBNS_BROADCAST", "NETBEUI", "ORACLE_TNS", "PPP", "PPP_DISC",
               "PPP_SES", "RARP", "RAW_FR", "RSVP", "SCA", "SCTP", "SUN_RPC_TCP",
-               "SUN_RPC_UDP", "TCP", "UDP", "X25", IgnoreCase=$false )]
+               "SUN_RPC_UDP", "TCP", "UDP", "X25" )]
             [string]$Protocol,
         [Parameter (Mandatory=$false)]
             [ValidateScript({
-                if (( @("TCP", "UDP") -ccontains $protocol ) -and ( $_ -notmatch "^[\d,-]+$" )) {
+                if (( @("TCP", "UDP") -contains $protocol ) -and ( $_ -notmatch "^[\d,-]+$" )) {
                     throw "TCP or UDP port numbers must be either an integer, range (nn-nn) or commma separated integers or ranges."
                 }
                 elseif ( ( @("FTP", "MS_RPC_TCP", "MS_RPC_UDP", "NBDG_BROADCAST", "NBNS_BROADCAST", "ORACLE_TNS", "SUN_RPC_TCP", "SUN_RPC_UDP")  -contains $Protocol ) -and (-not ( ($_ -as [int]) -and ( (1..65535) -contains $_ )))) {
                     throw "Valid port numbers must be an integer between 1-65535."
                 }
-                elseif (( $protocol -eq "ICMP") -and ( $AllValidIcmpTypes -cnotcontains $_ )) {
+                elseif (( $protocol -eq "ICMP") -and ( $AllValidIcmpTypes -notcontains $_ )) {
                     throw "Invalid ICMP protocol $_.  Specify one of $($AllValidIcmpTypes -join ", ")"
                 }
                 elseif (($protocol -eq "L2_OTHERS") -and ( $_ -notmatch "0x[0-9A-Fa-f]{4}" )) {
@@ -20486,6 +20500,8 @@ function New-NsxService  {
             [string]$port,
         [Parameter (Mandatory=$false)]
             [string]$scopeId="globalroot-0",
+        [Parameter (Mandatory=$false)]
+            [switch]$ReturnObjectIdOnly=$false,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -20513,7 +20529,7 @@ function New-NsxService  {
         [System.XML.XMLElement]$xmlElement = $XMLDoc.CreateElement("element")
         $xmlRoot.appendChild($xmlElement) | out-null
 
-        Add-XmlElement -xmlRoot $xmlElement -xmlElementName "applicationProtocol" -xmlElementText $Protocol
+        Add-XmlElement -xmlRoot $xmlElement -xmlElementName "applicationProtocol" -xmlElementText $Protocol.ToUpper()
         if ( $PSBoundParameters.ContainsKey("Port")) {
             Add-XmlElement -xmlRoot $xmlElement -xmlElementName "value" -xmlElementText $Port
         }
@@ -20522,7 +20538,12 @@ function New-NsxService  {
         $URI = "/api/2.0/services/application/$scopeId"
         $response = invoke-nsxwebrequest -method "post" -uri $URI -body $body -connection $connection
 
-        Get-NsxService -objectId $response.content -connection $connection
+        if ( $ReturnObjectIdOnly) {
+            $response.content
+        }
+        else {
+            Get-NsxService -objectId $response.content -connection $connection
+        }
     }
     end {}
 }
@@ -20910,6 +20931,8 @@ function New-NsxServiceGroup {
         [Parameter (Mandatory=$false)]
             [ValidateNotNull()]
             [string]$Description = "",
+        [Parameter (Mandatory=$false)]
+            [switch]$ReturnObjectIdOnly=$false,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -20936,8 +20959,12 @@ function New-NsxServiceGroup {
         $uri = "/api/2.0/services/applicationgroup/globalroot-0"
         $response = invoke-nsxwebrequest -uri $uri -method $method -body $body -connection $connection
 
-        Get-NsxServiceGroup $Name
-
+        if ( $ReturnObjectIdOnly) {
+            $response.content
+        }
+        else {
+            Get-NsxServiceGroup -objectId $response.content -connection $connection
+        }
     }
 
     end {}

--- a/tests/integration/03.LogicalRouter.Tests.ps1
+++ b/tests/integration/03.LogicalRouter.Tests.ps1
@@ -137,7 +137,7 @@ Describe "Logical Routing" {
             $rule | should be $null
         }
 
-        it "Can retreive an emty result set of redistribution rules" {
+        it "Can retreive an empty result set of redistribution rules" {
             Get-NsxLogicalRouter $Name | Get-NsxLogicalRouterRouting | Get-NsxLogicalRouterRedistributionRule | Remove-NsxLogicalRouterRedistributionRule -Confirm:$false
             $rule = Get-NsxLogicalRouter $Name | Get-NsxLogicalRouterRouting | Get-NsxLogicalRouterRedistributionRule
             $rule | should be $null

--- a/tests/integration/04.Edge.Tests.ps1
+++ b/tests/integration/04.Edge.Tests.ps1
@@ -291,7 +291,7 @@ Describe "Edge" {
             $rule | should be $null
         }
 
-        it "Can retreive an emty result set of redistribution rules" {
+        it "Can retreive an empty result set of redistribution rules" {
             $rtg = Get-NsxEdge $name | Get-NsxEdgeRouting
             $rtg | should not be $null
             $rtg | Get-NsxEdgeRedistributionRule | Remove-NsxEdgeRedistributionRule -Confirm:$false

--- a/tests/integration/08.Service.Tests.ps1
+++ b/tests/integration/08.Service.Tests.ps1
@@ -1,4 +1,4 @@
-#PowerNSX Test template.
+#PowerNSX Service Tests.
 #Nick Bradford : nbradford@vmware.com
 
 #Because PowerNSX is an API consumption tool, its test framework is limited to
@@ -76,6 +76,34 @@ Describe "Services" {
         disconnect-nsxserver
     }
 
+    Context "Service retrieval" {
+        BeforeAll {
+            $script:svcName = "$svcPrefix-get"
+            $svcDesc = "PowerNSX Pester Test get service"
+            $svcPort = 1234
+            $svcProto = "TCP"
+            $script:get = New-NsxService -Name $svcName -Description $svcDesc -Protocol $svcProto -port $svcPort
+
+        }
+
+        it "Can retreive a service by name" {
+            {Get-NsxService -Name $svcName} | should not throw
+            $svc = Get-NsxService -Name $svcName
+            $svc | should not be $null
+            $svc.name | should be $svcName
+
+         }
+
+        it "Can retreive a service by id" {
+            {Get-NsxService -objectId $get.objectId } | should not throw
+            $svc = Get-NsxService -objectId $get.objectId
+            $svc | should not be $null
+            $svc.objectId | should be $get.objectId
+         }
+
+
+    }
+
     Context "Successful Service Creation" {
 
         AfterAll {
@@ -135,6 +163,28 @@ Describe "Services" {
 
             }
         }
+
+        it "Can create a service and return an objectId only" {
+            $svcName = "$svcPrefix-objonly-1234"
+            $svcDesc = "PowerNSX Pester Test objectidonly service"
+            $svcPort = 1234
+            $svcProto = "TCP"
+            $id = New-NsxService -Name $svcName -Description $svcDesc -Protocol $svcProto -port $svcPort -ReturnObjectIdOnly
+            $id | should BeOfType System.String
+            $id | should match "^application-\d*$"
+
+         }
+
+         it "Can create a service using a lowercase servicename" {
+            $svcName = "$svcPrefix-lowercase-1234"
+            $svcDesc = "PowerNSX Pester Test lowercase service"
+            $svcPort = 1234
+            $svcProto = "tcp"
+            $id = New-NsxService -Name $svcName -Description $svcDesc -Protocol $svcProto -port $svcPort -ReturnObjectIdOnly
+            $id | should BeOfType System.String
+            $id | should match "^application-\d*$"
+
+         }
     }
 
     Context "Unsuccessful Service Creation" {
@@ -193,17 +243,20 @@ Describe "Services" {
 
     Context "Service Deletion" {
 
-
-        it "Can delete a service by object" {
-
+        BeforeEach {
             $svcName = "$svcPrefix-delete"
             $svcDesc = "PowerNSX Pester Test delete service"
             $svcPort = 1234
             $svcProto = "TCP"
-            $delete = New-NsxService -Name $svcName -Description $svcDesc -Protocol $svcProto -port $svcPort
+            $script:delete = New-NsxService -Name $svcName -Description $svcDesc -Protocol $svcProto -port $svcPort
+
+        }
+
+        it "Can delete a service by object" {
 
             $delete | Remove-NsxService -confirm:$false
-            {Get-NsxService -objectId $svc.objectId} | should throw
+            {Get-NsxService -objectId $delete.objectId} | should throw
         }
+
     }
 }

--- a/tests/integration/09.ServiceGroups.Tests.ps1
+++ b/tests/integration/09.ServiceGroups.Tests.ps1
@@ -1,0 +1,132 @@
+#PowerNSX ServiceGroup Tests.
+#Nick Bradford : nbradford@vmware.com
+
+#Because PowerNSX is an API consumption tool, its test framework is limited to
+#exercising cmdlet functionality against a functional NSX and vSphere API
+#If you disagree with this approach - feel free to start writing mocks for all
+#potential API reponses... :)
+
+#In the meantime, the test format is not as elegant as normal TDD, but Ive made some effort to get close to this.
+#Each functional area in NSX should have a separate test file.
+
+#Try to group related tests in contexts.  Especially ones that rely on configuration done in previous tests
+#Try to make tests as standalone as possible, but generally round trips to the API are expensive, so bear in mind
+#the time spent recreating configuration created in previous tests just for the sake of keeping test isolation.
+
+#Try to put all non test related setup and tear down in the BeforeAll and AfterAll sections.  ]
+#If a failure in here occurs, the Describe block is not executed.
+
+#########################
+#Do not remove this - we need to ensure connection setup and module deps preload have occured.
+If ( -not $PNSXTestNSXManager ) {
+    Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
+}
+
+Describe "ServiceGroups" {
+
+    BeforeAll {
+
+        #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
+        #We load the mod and establish connection to NSX Manager here.
+
+        #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
+        import-module $pnsxmodule
+        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+
+        #Put any script scope variables you need to reference in your tests.
+        #For naming items that will be created in NSX, use a unique prefix
+        #pester_<testabbreviation>_<objecttype><uid>.  example:
+        $script:svcPrefix = "pester_svcgrp_"
+
+        #Clean up any existing services from previous runs...
+        get-nsxservicegroup | ? { $_.name -match $svcPrefix } | remove-nsxservicegroup -confirm:$false
+
+
+    }
+
+    AfterAll {
+        #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
+        #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
+        #We kill the connection to NSX Manager here.
+
+        get-nsxservicegroup | ? { $_.name -match $svcPrefix } | remove-nsxservicegroup -confirm:$false
+
+        disconnect-nsxserver
+    }
+
+    Context "ServiceGroup retrieval" {
+        BeforeAll {
+            $script:svcGrpName = "$svcPrefix-get"
+            $svcGrpDesc = "PowerNSX Pester Test get serviceGroup"
+            $script:get = New-NsxServiceGroup -Name $svcGrpName -Description $svcGrpDesc
+
+        }
+
+        it "Can retreive a service group by name" {
+            {Get-NsxServiceGroup -Name $svcGrpName} | should not throw
+            $sg = Get-NsxServiceGroup -Name $svcGrpName
+            $sg | should not be $null
+            $sg.name | should be $svcGrpName
+
+         }
+
+        it "Can retreive a service group by id" {
+            {Get-NsxServiceGroup -objectId $get.objectId } | should not throw
+            $sg = Get-NsxServiceGroup -objectId $get.objectId
+            $sg | should not be $null
+            $sg.objectId | should be $get.objectId
+         }
+
+
+    }
+
+    Context "Successful Service Group Creation" {
+
+        AfterAll {
+            get-nsxserviceGroup | ? { $_.name -match $svcPrefix } | remove-nsxserviceGroup -confirm:$false
+        }
+
+        it "Can create a service group" {
+
+            $svcGrpName = "$svcPrefix-sg"
+            $svcDesc = "PowerNSX Pester Test service group"
+            $svcgrp = New-NsxServiceGroup -Name $svcGrpName -Description $svcDesc
+            $svcgrp.Name | Should be $svcGrpName
+            $svcgrp.Description | should be $svcDesc
+            $get = Get-NsxServiceGroup -Name $svcGrpName
+            $get.name | should be $svcgrp.name
+            $get.description | should be $svcgrp.description
+            $get.element.protocol | should be $svcgrp.element.protocol
+
+        }
+
+
+        it "Can create a service group and return an objectId only" {
+            $svcGrpName = "$svcPrefix-objonly-1234"
+            $svcDesc = "PowerNSX Pester Test objectidonly service"
+            $id = New-NsxServiceGroup -Name $svcGrpName -Description $svcDesc -ReturnObjectIdOnly
+            $id | should BeOfType System.String
+            $id | should match "^applicationgroup-\d*$"
+
+         }
+
+    }
+
+
+    Context "Service Group Deletion" {
+
+        BeforeEach {
+            $svcGrpName = "$svcPrefix-delete"
+            $svcDesc = "PowerNSX Pester Test delete service group"
+            $script:delete = New-NsxServiceGroup -Name $svcGrpName -Description $svcDesc
+
+        }
+
+        it "Can delete a servicegroup by object" {
+
+            $delete | Remove-NsxServiceGroup -confirm:$false
+            {Get-NsxServiceGroup -objectId $delete.objectId} | should throw
+        }
+
+    }
+}

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -1,0 +1,172 @@
+#PowerNSX IPSet Tests.
+#Nick Bradford : nbradford@vmware.com
+
+#Because PowerNSX is an API consumption tool, its test framework is limited to
+#exercising cmdlet functionality against a functional NSX and vSphere API
+#If you disagree with this approach - feel free to start writing mocks for all
+#potential API reponses... :)
+
+#In the meantime, the test format is not as elegant as normal TDD, but Ive made some effort to get close to this.
+#Each functional area in NSX should have a separate test file.
+
+#Try to group related tests in contexts.  Especially ones that rely on configuration done in previous tests
+#Try to make tests as standalone as possible, but generally round trips to the API are expensive, so bear in mind
+#the time spent recreating configuration created in previous tests just for the sake of keeping test isolation.
+
+#Try to put all non test related setup and tear down in the BeforeAll and AfterAll sections.  ]
+#If a failure in here occurs, the Describe block is not executed.
+
+#########################
+#Do not remove this - we need to ensure connection setup and module deps preload have occured.
+If ( -not $PNSXTestNSXManager ) {
+    Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
+}
+
+Describe "IPSets" {
+
+    BeforeAll {
+
+        #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
+        #We load the mod and establish connection to NSX Manager here.
+
+        #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
+        import-module $pnsxmodule
+        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+
+        #Put any script scope variables you need to reference in your tests.
+        #For naming items that will be created in NSX, use a unique prefix
+        #pester_<testabbreviation>_<objecttype><uid>.  example:
+        $script:IpSetPrefix = "pester_ipset_"
+
+        #Clean up any existing ipsets from previous runs...
+        get-nsxipset | ? { $_.name -match $IpSetPrefix } | remove-nsxipset -confirm:$false
+
+
+    }
+
+    AfterAll {
+        #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
+        #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
+        #We kill the connection to NSX Manager here.
+
+        get-nsxipset | ? { $_.name -match $IpSetPrefix } | remove-nsxipset -confirm:$false
+
+        disconnect-nsxserver
+    }
+
+    Context "IpSet retrieval" {
+        BeforeAll {
+            $script:ipsetName = "$IpSetPrefix-get"
+            $ipSetDesc = "PowerNSX Pester Test get ipset"
+            $script:get = New-nsxipset -Name $ipsetName -Description $ipSetDesc
+
+        }
+
+        it "Can retreive an ipset by name" {
+            {Get-nsxipset -Name $ipsetName} | should not throw
+            $ipset = Get-nsxipset -Name $ipsetName
+            $ipset | should not be $null
+            $ipset.name | should be $ipsetName
+
+         }
+
+        it "Can retreive an ipset by id" {
+            {Get-nsxipset -objectId $get.objectId } | should not throw
+            $ipset = Get-nsxipset -objectId $get.objectId
+            $ipset | should not be $null
+            $ipset.objectId | should be $get.objectId
+         }
+    }
+
+    Context "Successful IpSet Creation" {
+
+        AfterAll {
+            get-nsxipset | ? { $_.name -match $IpSetPrefix } | remove-nsxipset -confirm:$false
+        }
+
+        it "Can create an ipset with single address" {
+
+            $ipsetName = "$IpSetPrefix-ipset-create1"
+            $ipsetDesc = "PowerNSX Pester Test create ipset"
+            $ipaddresses = "1.2.3.4"
+            $ipset = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses $ipaddresses
+            $ipset.Name | Should be $ipsetName
+            $ipset.Description | should be $ipsetDesc
+            $get = Get-nsxipset -Name $ipsetName
+            $get.name | should be $ipset.name
+            $get.description | should be $ipset.description
+            $get.value | should be $ipset.value
+
+        }
+
+        it "Can create an ipset with range" {
+
+            $ipsetName = "$IpSetPrefix-ipset-create2"
+            $ipsetDesc = "PowerNSX Pester Test create ipset"
+            $ipaddresses = "1.2.3.4-2.3.4.5"
+            $ipset = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses $ipaddresses
+            $ipset.Name | Should be $ipsetName
+            $ipset.Description | should be $ipsetDesc
+            $get = Get-nsxipset -Name $ipsetName
+            $get.name | should be $ipset.name
+            $get.description | should be $ipset.description
+            $get.value | should be $ipset.value
+
+        }
+
+        it "Can create an ipset with CIDR" {
+
+            $ipsetName = "$IpSetPrefix-ipset-create3"
+            $ipsetDesc = "PowerNSX Pester Test create ipset"
+            $ipaddresses = "1.2.3.0/24"
+            $ipset = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses $ipaddresses
+            $ipset.Name | Should be $ipsetName
+            $ipset.Description | should be $ipsetDesc
+            $get = Get-nsxipset -Name $ipsetName
+            $get.name | should be $ipset.name
+            $get.description | should be $ipset.description
+            $get.value | should be $ipset.value
+
+        }
+
+
+        it "Can create an ipset and return an objectId only" {
+            $ipsetName = "$IpSetPrefix-objonly-1234"
+            $ipsetDesc = "PowerNSX Pester Test objectidonly ipset"
+            $ipaddresses = "1.2.3.4"
+            $id = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses $ipaddresses -ReturnObjectIdOnly
+            $id | should BeOfType System.String
+            $id | should match "^ipset-\d*$"
+
+         }
+    }
+
+    Context "Unsuccessful IpSet Creation" {
+
+        it "Fails to create an ipset with invalid address" {
+
+            $ipsetName = "$IpSetPrefix-ipset-create1"
+            $ipsetDesc = "PowerNSX Pester Test create ipset"
+            $ipaddresses = "1.2.3.4.5"
+            { New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses $ipaddresses } | should throw
+        }
+    }
+
+
+    Context "IpSet Deletion" {
+
+        BeforeEach {
+            $ipsetName = "$IpSetPrefix-delete"
+            $ipsetDesc = "PowerNSX Pester Test delete IpSet"
+            $script:delete = New-nsxipset -Name $ipsetName -Description $ipsetDesc
+
+        }
+
+        it "Can delete an ipset by object" {
+
+            $delete | Remove-nsxipset -confirm:$false
+            {Get-nsxipset -objectId $delete.objectId} | should throw
+        }
+
+    }
+}

--- a/tests/integration/11.SecurityGroups.Tests.ps1
+++ b/tests/integration/11.SecurityGroups.Tests.ps1
@@ -1,0 +1,132 @@
+#PowerNSX SecurityGroup Tests.
+#Nick Bradford : nbradford@vmware.com
+
+#Because PowerNSX is an API consumption tool, its test framework is limited to
+#exercising cmdlet functionality against a functional NSX and vSphere API
+#If you disagree with this approach - feel free to start writing mocks for all
+#potential API reponses... :)
+
+#In the meantime, the test format is not as elegant as normal TDD, but Ive made some effort to get close to this.
+#Each functional area in NSX should have a separate test file.
+
+#Try to group related tests in contexts.  Especially ones that rely on configuration done in previous tests
+#Try to make tests as standalone as possible, but generally round trips to the API are expensive, so bear in mind
+#the time spent recreating configuration created in previous tests just for the sake of keeping test isolation.
+
+#Try to put all non test related setup and tear down in the BeforeAll and AfterAll sections.  ]
+#If a failure in here occurs, the Describe block is not executed.
+
+#########################
+#Do not remove this - we need to ensure connection setup and module deps preload have occured.
+If ( -not $PNSXTestNSXManager ) {
+    Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
+}
+
+Describe "SecurityGroups" {
+
+    BeforeAll {
+
+        #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
+        #We load the mod and establish connection to NSX Manager here.
+
+        #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
+        import-module $pnsxmodule
+        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+
+        #Put any script scope variables you need to reference in your tests.
+        #For naming items that will be created in NSX, use a unique prefix
+        #pester_<testabbreviation>_<objecttype><uid>.  example:
+        $script:sgPrefix = "pester_secgrp_"
+
+        #Clean up any existing SGs from previous runs...
+        get-nsxsecuritygroup | ? { $_.name -match $sgPrefix } | remove-nsxsecuritygroup -confirm:$false
+
+
+    }
+
+    AfterAll {
+        #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
+        #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
+        #We kill the connection to NSX Manager here.
+
+        get-nsxsecuritygroup | ? { $_.name -match $sgPrefix } | remove-nsxsecuritygroup -confirm:$false
+
+        disconnect-nsxserver
+    }
+
+    Context "SecurityGroup retrieval" {
+        BeforeAll {
+            $script:secGrpName = "$sgPrefix-get"
+            $SecGrpDesc = "PowerNSX Pester Test get SecurityGroup"
+            $script:get = New-nsxsecuritygroup -Name $secGrpName -Description $SecGrpDesc
+
+        }
+
+        it "Can retreive a SecurityGroup by name" {
+            {Get-nsxsecuritygroup -Name $secGrpName} | should not throw
+            $sg = Get-nsxsecuritygroup -Name $secGrpName
+            $sg | should not be $null
+            $sg.name | should be $secGrpName
+
+         }
+
+        it "Can retreive a SecurityGroup by id" {
+            {Get-nsxsecuritygroup -objectId $get.objectId } | should not throw
+            $sg = Get-nsxsecuritygroup -objectId $get.objectId
+            $sg | should not be $null
+            $sg.objectId | should be $get.objectId
+         }
+
+
+    }
+
+    Context "Successful SecurityGroup Creation" {
+
+        AfterAll {
+            get-nsxsecuritygroup | ? { $_.name -match $sgPrefix } | remove-nsxsecuritygroup -confirm:$false
+        }
+
+        it "Can create a SecurityGroup" {
+
+            $secGrpName = "$sgPrefix-sg"
+            $SecGrpDesc = "PowerNSX Pester Test SecurityGroup"
+            $secGrp = New-nsxsecuritygroup -Name $secGrpName -Description $SecGrpDesc
+            $secGrp.Name | Should be $secGrpName
+            $secGrp.Description | should be $SecGrpDesc
+            $get = Get-nsxsecuritygroup -Name $secGrpName
+            $get.name | should be $secGrp.name
+            $get.description | should be $secGrp.description
+            $get.element.protocol | should be $secGrp.element.protocol
+
+        }
+
+
+        it "Can create a SecurityGroup and return an objectId only" {
+            $secGrpName = "$sgPrefix-objonly-1234"
+            $SecGrpDesc = "PowerNSX Pester Test objectidonly SecurityGroup"
+            $id = New-nsxsecuritygroup -Name $secGrpName -Description $SecGrpDesc -ReturnObjectIdOnly
+            $id | should BeOfType System.String
+            $id | should match "^securitygroup-\d*$"
+
+         }
+
+    }
+
+
+    Context "SecurityGroup Deletion" {
+
+        BeforeEach {
+            $secGrpName = "$sgPrefix-delete"
+            $SecGrpDesc = "PowerNSX Pester Test delete SecurityGroup"
+            $script:delete = New-nsxsecuritygroup -Name $secGrpName -Description $SecGrpDesc
+
+        }
+
+        it "Can delete a SecurityGroup by object" {
+
+            $delete | Remove-nsxsecuritygroup -confirm:$false
+            {Get-nsxsecuritygroup -objectId $delete.objectId} | should throw
+        }
+
+    }
+}


### PR DESCRIPTION
Ipsets, Services, Service Groups and SecurityGroups
have ReturnObjectIdOnly switch now
to prevent the automatic get against
the API when a new instance is created.
In mass import scenarios, this is a significant
performance benefit.

Add tests