### PR TITLE
Dfw threshold

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -319,10 +319,13 @@ FunctionsToExport = @(
     'Get-NsxLicense',
     'Get-NsxApplicableMember',
     'Get-NsxSecurityGroupMemberTypes',
+    'Get-NsxFirewallThreshold',
+    'Set-NsxFirewallThreshold',
     'Get-NsxSecurityGroupEffectiveVirtualMachine',
     'Get-NsxSecurityGroupEffectiveIpAddress',
     'Get-NsxSecurityGroupEffectiveMacAddress',
     'Get-NsxSecurityGroupEffectiveVnic'
+
 )
 
 # Cmdlets to export from this module

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -284,7 +284,7 @@ FunctionsToExport = @(
     'Remove-NsxLoadBalancerVip',
     'Get-NsxSecurityPolicy',
     'Remove-NsxSecurityPolicy',
-    'Get-NsxSecurityGroupEffectiveMembers',
+    'Get-NsxSecurityGroupEffectiveMember',
     'Find-NsxWhereVMUsed',
     'Get-NsxBackingPortGroup',
     'Get-NsxBackingDVSwitch',
@@ -318,7 +318,11 @@ FunctionsToExport = @(
     'Add-NsxLicense',
     'Get-NsxLicense',
     'Get-NsxApplicableMember',
-    'Get-NsxSecurityGroupMemberTypes'
+    'Get-NsxSecurityGroupMemberTypes',
+    'Get-NsxSecurityGroupEffectiveVirtualMachine',
+    'Get-NsxSecurityGroupEffectiveIpAddress',
+    'Get-NsxSecurityGroupEffectiveMacAddress',
+    'Get-NsxSecurityGroupEffectiveVnic'
 )
 
 # Cmdlets to export from this module

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -325,7 +325,6 @@ FunctionsToExport = @(
     'Get-NsxSecurityGroupEffectiveIpAddress',
     'Get-NsxSecurityGroupEffectiveMacAddress',
     'Get-NsxSecurityGroupEffectiveVnic'
-
 )
 
 # Cmdlets to export from this module

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -22452,6 +22452,14 @@ function Get-NsxFirewallThreshold {
 
 
     #>
+    param (
+
+        [Parameter (Mandatory=$false)]
+            #PowerNSX Connection object.
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+
+    )
 
     begin {
 
@@ -22460,16 +22468,22 @@ function Get-NsxFirewallThreshold {
     process { 
         
         $URI = "/api/4.0/firewall/stats/eventthresholds"
-        $response = invoke-nsxwebrequest -method "get" -uri $URI -connection $connection
-       
-        $threshold=[system.xml.xmldocument]$response.content
         
-        [PSCustomobject]@{
-                "CPU" = $threshold.eventthresholds.cpu.percentvalue;
-                "Memory" = $threshold.eventthresholds.memory.percentvalue;
-                "ConnectionsPerSecond" = $threshold.eventThresholds.connectionsPerSecond.value
-            }
-    
+        try {
+            $response = invoke-nsxwebrequest -method "get" -uri $URI -connection $connection
+            [system.xml.xmldocument]$Content = $response.content
+            
+        }
+        
+        catch {
+            Throw "Unexpected API response $_"
+        }
+
+        if ( Invoke-XPathQuery -Node $content -QueryMethod SelectSingleNode -query "child::eventThresholds" ){
+            
+        $Content.eventThresholds
+
+        }
     }
 
     end{}
@@ -22520,49 +22534,29 @@ function Set-NsxFirewallThreshold {
 
     begin {
 
-        #Create the XMLRoot
-        [System.XML.XMLDocument]$xmlDoc = New-Object System.XML.XMLDocument
-        [System.XML.XMLElement]$xmlRoot = $XMLDoc.CreateElement("eventThresholds")
-        $xmlDoc.appendChild($xmlRoot) | out-null
-
-        #Create an Element and append it to the root
-        [System.XML.XMLElement]$xmlcpu = $xmlDoc.CreateElement("cpu")
-        [System.XML.XMLElement]$xmlmemory = $xmlDoc.CreateElement("memory")
-        [System.XML.XMLElement]$xmlconnections = $xmlDoc.CreateElement("connectionsPerSecond")
-
         #Capture existing thresholds
-        $CurrentThreshold =  Get-NsxFirewallThreshold
+        $currentthreshold =  Get-NsxFirewallThreshold
 
         #Using PSBoundParamters.ContainsKey lets us know if the user called us with a given parameter.
         #If the user did not specify a given parameter, we dont want to modify from the existing value.
 
         if ( $PsBoundParameters.ContainsKey('Cpu') ) {
-            Add-XmlElement -xmlRoot $xmlcpu -xmlElementName "percentValue" -xmlElementText $Cpu
-            } 
-        else {
-            Add-XmlElement -xmlRoot $xmlcpu -xmlElementName "percentValue" -xmlElementText $CurrentThreshold.Cpu
-        }
+             $currentthreshold.cpu.percentValue = $Cpu
+        } 
+       
 
         if ( $PsBoundParameters.ContainsKey('Memory') ) {
-            Add-XmlElement -xmlRoot $xmlmemory -xmlElementName "percentValue" -xmlElementText $Memory
-            } 
-        else {
-            Add-XmlElement -xmlRoot $xmlmemory -xmlElementName "percentValue" -xmlElementText $CurrentThreshold.Memory
-        }
+            $currentthreshold.memory.percentValue = $Memory
+        } 
+        
 
         if ( $PsBoundParameters.ContainsKey('ConnectionsPerSecond') ) { 
-            Add-XmlElement -xmlRoot $xmlconnections -xmlElementName "value" -xmlElementText $ConnectionsPerSecond
-            } 
-        else {
-            Add-XmlElement -xmlRoot $xmlconnections -xmlElementName "value" -xmlElementText $CurrentThreshold.ConnectionsPerSecond
-        }
-    
-        $xmlRoot.AppendChild($xmlcpu) | out-null
-        $xmlRoot.AppendChild($xmlmemory) | out-null
-        $xmlRoot.AppendChild($xmlconnections) | out-null
+            $currentthreshold.connectionsPerSecond.value = $ConnectionsPerSecond
+        } 
+      
         $uri = "/api/4.0/firewall/stats/eventthresholds"
         
-        $body = $xmlroot.outerXml
+        $body = $currentthreshold.outerXml
         Invoke-NsxWebRequest -method "PUT" -URI $uri -body $body | out-null
 
         Get-NsxFirewallThreshold

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -9960,7 +9960,7 @@ function Clear-NsxEdgeInterface {
 
         if ( $confirm ) {
 
-            $message  = "Interface ($Interface.Name) config will be cleared."
+            $message  = "Interface $($Interface.Name) config will be cleared."
             $question = "Proceed with interface reconfiguration for interface $($interface.index)?"
 
             $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5832,6 +5832,16 @@ function New-NsxIpPool {
 
     The New-NsxIpPool cmdlet creates a new IP Pool on the connected NSX manager.
 
+    .EXAMPLE
+    New-NsxIpPool -name Controller_Pool -Gateway "192.168.103.1" 
+    -SubnetPrefixLength "24" -DnsServer1 "192.168.100.4" -DnsSuffix "lab.local"
+    -StartAddress "192.168.103.101" -EndAddress "192.168.103.115"
+
+    This example creates a pool called Controller_Pool. It uses the IP range
+    192.168.103.101-115, has a defined gateway of 192.168.103.1 and has DNS
+    settings configured.
+
+
     #>
 
 
@@ -5937,8 +5947,15 @@ function Get-NsxIpPool {
     address asignment for multiple NSX technologies including VTEP interfaces
     NSX Controllers.
 
+    .EXAMPLE
+    This example retrieves all NSX IP Pools
 
-    The Get-IpPool cmdlet retreives an NSX IP Pools
+    Get-NsxIpPool
+
+    .EXAMPLE
+    This example retrieves an NSX IP Pool by name
+
+    Get-NsxIpPool -name Controller_Pool
 
     #>
 
@@ -20243,6 +20260,16 @@ function Get-NsxMacSet {
 
     This cmdlet returns MAC Set objects.
 
+    .EXAMPLE
+    Retrieves all NSX MAC Sets
+
+    Get-NsxMacSet
+
+    .EXAMPLE
+    Retrieves NSX MAC Set by name
+
+    Get-NsxMacSet TEST_MAC_SET
+
     #>
 
     [CmdLetBinding(DefaultParameterSetName="Name")]
@@ -20334,6 +20361,11 @@ function New-NsxMacSet  {
     separated by commas
     Mac address: (eg, 00:00:00:00:00:00)
 
+    .EXAMPLE
+    Creates a MAC Set with the MAC address BEEF:CAFE:DEAD
+
+    PS /Users/Anthony> new-nsxmacset -name MAC_SET_TEST -Description "A sample MAC"
+     -MacAddresses "BE:EF:CA:FE:DE:AD"
 
     #>
 
@@ -20398,7 +20430,13 @@ function Remove-NsxMacSet {
     but be aware that the firewall rulebase will become invalid and will need
     to be corrected before publish operations will succeed again.
 
+    .EXAMPLE
 
+    This will remove a MAC Set by name.
+
+    Get-NsxMacSet MAC_SET_TEST | Remove-NsxMacSet
+
+    -confirm:$false can be used to avoid being prompted.
     #>
 
     param (

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -22457,25 +22457,20 @@ function Get-NsxFirewallThreshold {
 
     }
 
-    process {
-        
+    process { 
         
         $URI = "/api/4.0/firewall/stats/eventthresholds"
         $response = invoke-nsxwebrequest -method "get" -uri $URI -connection $connection
        
-        
         $threshold=[system.xml.xmldocument]$response.content
-
+        
         [PSCustomobject]@{
-                    "CPU" = $threshold.eventthresholds.cpu.percentvalue;
-                    "Memory" = $threshold.eventthresholds.memory.percentvalue;
-                    "ConnectionsPerSecond" = $threshold.eventThresholds.connectionsPerSecond.value
-                }
+                "CPU" = $threshold.eventthresholds.cpu.percentvalue;
+                "Memory" = $threshold.eventthresholds.memory.percentvalue;
+                "ConnectionsPerSecond" = $threshold.eventThresholds.connectionsPerSecond.value
+            }
     
     }
-
-        
-       
 
     end{}
 }
@@ -22507,16 +22502,16 @@ function Set-NsxFirewallThreshold {
 
     param (
 
-        [Parameter (Mandatory=$true)]
+        [Parameter (Mandatory=$false)]
             [ValidateRange(1,100)]
             [int]$Memory,
-        [Parameter (Mandatory=$true)]
+        [Parameter (Mandatory=$false)]
             [ValidateRange(1,100)]
             [int]$Cpu,
-        [Parameter (Mandatory=$true)]
+        [Parameter (Mandatory=$false)]
             [ValidateRange(1,500000)]
             [int]$ConnectionsPerSecond,
-        [Parameter (Mandatory=$False)]
+        [Parameter (Mandatory=$false)]
             #PowerNSX Connection object.
             [ValidateNotNullOrEmpty()]
             [PSCustomObject]$Connection=$defaultNSXConnection
@@ -22525,38 +22520,54 @@ function Set-NsxFirewallThreshold {
 
     begin {
 
-         #Create the XMLRoot
-            [System.XML.XMLDocument]$xmlDoc = New-Object System.XML.XMLDocument
-            [System.XML.XMLElement]$xmlRoot = $XMLDoc.CreateElement("eventThresholds")
-            $xmlDoc.appendChild($xmlRoot) | out-null
+        #Create the XMLRoot
+        [System.XML.XMLDocument]$xmlDoc = New-Object System.XML.XMLDocument
+        [System.XML.XMLElement]$xmlRoot = $XMLDoc.CreateElement("eventThresholds")
+        $xmlDoc.appendChild($xmlRoot) | out-null
 
-            #Create an Element and append it to the root
+        #Create an Element and append it to the root
+        [System.XML.XMLElement]$xmlcpu = $xmlDoc.CreateElement("cpu")
+        [System.XML.XMLElement]$xmlmemory = $xmlDoc.CreateElement("memory")
+        [System.XML.XMLElement]$xmlconnections = $xmlDoc.CreateElement("connectionsPerSecond")
 
-            [System.XML.XMLElement]$xmlcpu = $xmlDoc.CreateElement("cpu")
-            [System.XML.XMLElement]$xmlmemory = $xmlDoc.CreateElement("memory")
-            [System.XML.XMLElement]$xmlconnections = $xmlDoc.CreateElement("connectionsPerSecond")
+        #Capture existing thresholds
+        $CurrentThreshold =  Get-NsxFirewallThreshold
 
+        #Using PSBoundParamters.ContainsKey lets us know if the user called us with a given parameter.
+        #If the user did not specify a given parameter, we dont want to modify from the existing value.
 
-            Add-XmlElement -xmlRoot $xmlcpu -xmlElementName "percentValue" -xmlElementText $cpu
-            Add-XmlElement -xmlRoot $xmlmemory -xmlElementName "percentValue" -xmlElementText $memory
+        if ( $PsBoundParameters.ContainsKey('Cpu') ) {
+            Add-XmlElement -xmlRoot $xmlcpu -xmlElementName "percentValue" -xmlElementText $Cpu
+            } 
+        else {
+            Add-XmlElement -xmlRoot $xmlcpu -xmlElementName "percentValue" -xmlElementText $CurrentThreshold.Cpu
+        }
+
+        if ( $PsBoundParameters.ContainsKey('Memory') ) {
+            Add-XmlElement -xmlRoot $xmlmemory -xmlElementName "percentValue" -xmlElementText $Memory
+            } 
+        else {
+            Add-XmlElement -xmlRoot $xmlmemory -xmlElementName "percentValue" -xmlElementText $CurrentThreshold.Memory
+        }
+
+        if ( $PsBoundParameters.ContainsKey('ConnectionsPerSecond') ) { 
             Add-XmlElement -xmlRoot $xmlconnections -xmlElementName "value" -xmlElementText $ConnectionsPerSecond
-            
-            $xmlRoot.AppendChild($xmlcpu) | out-null
-            $xmlRoot.AppendChild($xmlmemory) | out-null
-            $xmlRoot.AppendChild($xmlconnections) | out-null
-            
+            } 
+        else {
+            Add-XmlElement -xmlRoot $xmlconnections -xmlElementName "value" -xmlElementText $CurrentThreshold.ConnectionsPerSecond
+        }
+    
+        $xmlRoot.AppendChild($xmlcpu) | out-null
+        $xmlRoot.AppendChild($xmlmemory) | out-null
+        $xmlRoot.AppendChild($xmlconnections) | out-null
+        $uri = "/api/4.0/firewall/stats/eventthresholds"
+        
+        $body = $xmlroot.outerXml
+        Invoke-NsxWebRequest -method "PUT" -URI $uri -body $body | out-null
 
-            $uri = "/api/4.0/firewall/stats/eventthresholds"
-            
-            $body = $xmlroot.outerXml
-            Invoke-NsxWebRequest -method "PUT" -URI $uri -body $body | out-null
-
-            Get-NsxFirewallThreshold
-
+        Get-NsxFirewallThreshold
     }
-
     end {}
-
 }
 
 ########

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -2681,6 +2681,23 @@ Function Validate-TagAssignment {
     }
 }
 
+Function Validate-FwSourceDestFilter {
+    Param (
+        [Parameter (Mandatory=$true)]
+        [object]$argument
+    )
+    if ( ($argument -as [ipaddress]) -or
+        ($argument -as [VMware.VimAutomation.ViCore.Interop.V1.Inventory.VirtualMachineInterop]) ) {
+        $true
+    }
+    elseif ( ($argument -as [string]) -and ($argument -match "^vm-\d+$") ) {
+        $True
+    }
+    else {
+        throw "Source or Destination Filter must be an IPAddress, VM object, or vmmoid"
+    }
+}
+
 
 
 ##########
@@ -21708,14 +21725,15 @@ function Get-NsxFirewallRule {
     #>
 
 
-    [CmdletBinding(DefaultParameterSetName="Section")]
+    [CmdletBinding(DefaultParameterSetName="Filter")]
 
     param (
 
         [Parameter (Mandatory=$true,ValueFromPipeline=$true,ParameterSetName="Section")]
-        [ValidateNotNull()]
+            [ValidateNotNull()]
             [System.Xml.XmlElement]$Section,
-        [Parameter (Mandatory=$false, Position=1)]
+        [Parameter (Mandatory=$false, Position=1, ParameterSetName="Filter")]
+        [Parameter (Mandatory=$false, Position=1, ParameterSetName="Section")]
             [ValidateNotNullorEmpty()]
             [string]$Name,
         [Parameter (Mandatory=$true,ParameterSetName="RuleId")]
@@ -21723,9 +21741,16 @@ function Get-NsxFirewallRule {
             [string]$RuleId,
         [Parameter (Mandatory=$false)]
             [string]$ScopeId="globalroot-0",
-        [Parameter (Mandatory=$false)]
+        [Parameter (Mandatory=$false,ParameterSetName="Section")]
+        [Parameter (Mandatory=$false,ParameterSetName="RuleId")]
             [ValidateSet("layer3sections","layer2sections","layer3redirectsections",ignorecase=$false)]
             [string]$RuleType="layer3sections",
+        [Parameter (Mandatory=$False,ParameterSetName="Filter")]
+            [ValidateScript({ Validate-FwSourceDestFilter $_ })]
+            [object]$Source,
+        [Parameter (Mandatory=$False,ParameterSetName="Filter")]
+            [ValidateScript({ Validate-FwSourceDestFilter $_ })]
+            [object]$Destination,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -21753,6 +21778,33 @@ function Get-NsxFirewallRule {
                         $response.section.rule
                     }
                 }
+            }
+        }
+        elseif ( $PSCmdlet.ParameterSetName -eq "Filter" )  {
+
+            Switch ( $Source ) {
+                { $_ -as [VMware.VimAutomation.ViCore.Interop.V1.Inventory.VirtualMachineInterop]} {
+                    $SourceString = $_.id -replace "virtualmachine-"
+                }
+                default {
+                    #either a vmmoid or ipaddress.
+                    $SourceString = $Source
+                }
+            }
+            Switch ( $Destination ) {
+                { $_ -as [VMware.VimAutomation.ViCore.Interop.V1.Inventory.VirtualMachineInterop]} {
+                    $DestinationString = $_.id -replace "virtualmachine-"
+                }
+                default {
+                    #either a vmmoid or ipaddress.
+                    $DestinationString = $Destination
+                }
+            }
+            $URI = "/api/4.0/firewall/$ScopeId/config?ruleType=LAYER3&source=$SourceString&destination=$DestinationString&name=$Name"
+
+            $response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+            if ( Invoke-XpathQuery -QueryMethod SelectSingleNode -query "descendant::filteredfirewallConfiguration/layer3Sections/section/rule" -Node $response ){
+                $response.filteredfirewallConfiguration.layer3Sections.Section.rule
             }
         }
         else {

--- a/tests/integration/01.Environment.Tests.ps1
+++ b/tests/integration/01.Environment.Tests.ps1
@@ -37,6 +37,8 @@ Describe "Environment" -Tags "Environment" {
 
     it "Has hosts connected it can deploy to"{}
 
+    it "Has a running controller"{}
+
     BeforeAll {
 
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -52,18 +52,7 @@ Describe "Distributed Firewall" {
         $script:TestMacSetName2 = "pester_dfw_macset2"
         $script:TestMac1 = "00:50:56:00:00:00"
         $script:TestMac2 = "00:50:56:00:00:01"
-        $script:cpuThreshold = "75"
-        $script:cpuThreshold1 = "85"
-        $script:memoryThreshold = "75"
-        $script:memoryThreshold1 = "85" 
-        $script:cpsThreshold = "125000"
-        $script:cpsThreshold1 = "200000"
-        $script:cpsDefault = "100000"
-        $script:memorydefault = "100"
-        $script:cpudefault = "100"
-        
-        
-        $script:
+      
 
         #Logical Switch
         $script:testls = Get-NsxTransportZone | select -first 1 | New-NsxLogicalSwitch $testlsname
@@ -135,49 +124,6 @@ Describe "Distributed Firewall" {
         write-host -ForegroundColor Green "Completed cleanup tasks for DFW tests"
 
     }
-
-    Context "DFW Global options" {
-        it "Can validate default DFW event thresholds"{
-            #Unsure if this is correct "test"
-            $threshold = Get-NsxFirewallThreshold
-            $threshold | should not be $null
-            $threshold.Cpu | should be $cpuDefault
-            $threshold.Memory | should be $memoryDefault
-            $threshold.ConnectionsPerSecond | should be $cpsDefault
-        }
-        it "Can adjust all DFW event thresholds" {
-            $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold -Memory $memorythreshold -ConnectionsPerSecond $cpsThreshold
-            $threshold | should not be $null
-            $threshold.Cpu | should be $cputhreshold
-            $threshold.Memory | should be $memorythreshold
-            $threshold.ConnectionsPerSecond | should be $cpsThreshold
-        }
-        it "Can adjust Memory DFW event threshold" {
-            $threshold = Set-NsxFirewallThreshold  -Memory $memorythreshold1
-            $threshold | should not be $null
-            
-            $threshold.Memory | should be $memorythreshold1
-        }
-        it "Can adjust CPU DFW event threshold" {
-            $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold1
-            $threshold | should not be $null
-            $threshold.Cpu | should be $cputhreshold1
-        }
-        it "Can adjust ConnectionsPerSecond DFW event thresholds" {
-            $threshold = Set-NsxFirewallThreshold -ConnectionsPerSecond $cpsThreshold1
-            $threshold | should not be $null
-            $threshold.ConnectionsPerSecond | should be $cpsThreshold1
-        }
-
-        it "Can adjust Global Containers"{
-
-        }
-
-        it "Can adjust TCP Optimisation"{
-
-        }
-    }
-     
 
     Context "L3 Sections" {
         it "Can create an L3 section" {

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -52,6 +52,9 @@ Describe "Distributed Firewall" {
         $script:TestMacSetName2 = "pester_dfw_macset2"
         $script:TestMac1 = "00:50:56:00:00:00"
         $script:TestMac2 = "00:50:56:00:00:01"
+        $script:cpuThreshold = "75"
+        $script:memoryThreshold = "75"
+        $script:cpsThreshold = "125000"
 
         #Logical Switch
         $script:testls = Get-NsxTransportZone | select -first 1 | New-NsxLogicalSwitch $testlsname
@@ -117,10 +120,30 @@ Describe "Distributed Firewall" {
         Get-NsxService $TestServiceName1 | Remove-NsxService -confirm:$false
         Get-NsxService $TestServiceName2 | Remove-NsxService -confirm:$false
 
+        Set-NsxFirewallThreshold -Cpu 100 -Memory 100 -ConnectionsPerSecond 100000 | out-null
+
         disconnect-nsxserver
         write-host -ForegroundColor Green "Completed cleanup tasks for DFW tests"
 
     }
+
+    Context "DFW Global options" {
+        it "Can adjust default DFW event threshold" {
+                $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold -Memory $memorythreshold -ConnectionsPerSecond $cpsThreshold
+                $threshold | should not be $null
+                $threshold.Cpu | should be $cputhreshold
+                $threshold.Memory | should be $memorythreshold
+                $threshold.ConnectionsPerSecond | should be $cpsThreshold
+        }
+        it "Can adjust Global Containers"{
+
+        }
+
+        it "Can adjust TCP Optimisation"{
+
+        }
+    }
+     
 
     Context "L3 Sections" {
         it "Can create an L3 section" {

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -53,8 +53,17 @@ Describe "Distributed Firewall" {
         $script:TestMac1 = "00:50:56:00:00:00"
         $script:TestMac2 = "00:50:56:00:00:01"
         $script:cpuThreshold = "75"
+        $script:cpuThreshold1 = "85"
         $script:memoryThreshold = "75"
+        $script:memoryThreshold1 = "85" 
         $script:cpsThreshold = "125000"
+        $script:cpsThreshold1 = "200000"
+        $script:cpsDefault = "100000"
+        $script:memorydefault = "100"
+        $script:cpudefault = "100"
+        
+        
+        $script:
 
         #Logical Switch
         $script:testls = Get-NsxTransportZone | select -first 1 | New-NsxLogicalSwitch $testlsname
@@ -128,13 +137,38 @@ Describe "Distributed Firewall" {
     }
 
     Context "DFW Global options" {
-        it "Can adjust default DFW event threshold" {
-                $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold -Memory $memorythreshold -ConnectionsPerSecond $cpsThreshold
-                $threshold | should not be $null
-                $threshold.Cpu | should be $cputhreshold
-                $threshold.Memory | should be $memorythreshold
-                $threshold.ConnectionsPerSecond | should be $cpsThreshold
+        it "Can validate default DFW event thresholds"{
+            #Unsure if this is correct "test"
+            $threshold = Get-NsxFirewallThreshold
+            $threshold | should not be $null
+            $threshold.Cpu | should be $cpuDefault
+            $threshold.Memory | should be $memoryDefault
+            $threshold.ConnectionsPerSecond | should be $cpsDefault
         }
+        it "Can adjust all DFW event thresholds" {
+            $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold -Memory $memorythreshold -ConnectionsPerSecond $cpsThreshold
+            $threshold | should not be $null
+            $threshold.Cpu | should be $cputhreshold
+            $threshold.Memory | should be $memorythreshold
+            $threshold.ConnectionsPerSecond | should be $cpsThreshold
+        }
+        it "Can adjust Memory DFW event threshold" {
+            $threshold = Set-NsxFirewallThreshold  -Memory $memorythreshold1
+            $threshold | should not be $null
+            
+            $threshold.Memory | should be $memorythreshold1
+        }
+        it "Can adjust CPU DFW event threshold" {
+            $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold1
+            $threshold | should not be $null
+            $threshold.Cpu | should be $cputhreshold1
+        }
+        it "Can adjust ConnectionsPerSecond DFW event thresholds" {
+            $threshold = Set-NsxFirewallThreshold -ConnectionsPerSecond $cpsThreshold1
+            $threshold | should not be $null
+            $threshold.ConnectionsPerSecond | should be $cpsThreshold1
+        }
+
         it "Can adjust Global Containers"{
 
         }

--- a/tests/integration/12.DFWGlobalOptions.ps1
+++ b/tests/integration/12.DFWGlobalOptions.ps1
@@ -1,0 +1,108 @@
+#PowerNSX Test template.
+#Nick Bradford : nbradford@vmware.com
+
+#Because PowerNSX is an API consumption tool, its test framework is limited to 
+#exercising cmdlet functionality against a functional NSX and vSphere API
+#If you disagree with this approach - feel free to start writing mocks for all
+#potential API reponses... :) 
+
+#In the meantime, the test format is not as elegant as normal TDD, but Ive made some effort to get close to this.
+#Each functional area in NSX should have a separate test file.
+
+#Try to group related tests in contexts.  Especially ones that rely on configuration done in previous tests
+#Try to make tests as standalone as possible, but generally round trips to the API are expensive, so bear in mind
+#the time spent recreating configuration created in previous tests just for the sake of keeping test isolation.
+
+#Try to put all non test related setup and tear down in the BeforeAll and AfterAll sections.  ]
+#If a failure in here occurs, the Describe block is not executed.
+
+#########################
+#Do not remove this - we need to ensure connection setup and module deps preload have occured.
+If ( -not $PNSXTestNSXManager ) { 
+    Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
+} 
+
+Describe "DFW Global Properties" { 
+
+    BeforeAll { 
+
+        #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
+        #We load the mod and establish connection to NSX Manager here.
+       
+        #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
+        import-module $pnsxmodule
+        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:Conn = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false -VIDefaultConnection:$false
+        # Threshold Variables
+        $script:cpuThreshold = "75"
+        $script:cpuThreshold1 = "85"
+        $script:memoryThreshold = "75"
+        $script:memoryThreshold1 = "85" 
+        $script:cpsThreshold = "125000"
+        $script:cpsThreshold1 = "200000"
+        $script:cpsDefault = "100000"
+        $script:memorydefault = "100"
+        $script:cpudefault = "100"
+
+    }
+
+    AfterAll { 
+        #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
+        #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
+        #We kill the connection to NSX Manager here.
+        
+        Set-NsxFirewallThreshold -Cpu 100 -Memory 100 -ConnectionsPerSecond 100000 | out-null
+        disconnect-nsxserver 
+        Remove-Variable -scope global -name "conn"
+    }
+
+    BeforeEach {
+
+    }
+
+    AfterEach {
+
+    }
+
+    Context "DFW Global options" {
+        it "Can validate default DFW event thresholds"{
+            #Unsure if this is correct "test"
+            $threshold = Get-NsxFirewallThreshold
+            $threshold | should not be $null
+            $threshold.Cpu.percentValue | should be $cpuDefault
+            $threshold.Memory.percentValue | should be $memoryDefault
+            $threshold.ConnectionsPerSecond.value | should be $cpsDefault
+        }
+        it "Can adjust all DFW event thresholds" {
+            $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold -Memory $memorythreshold -ConnectionsPerSecond $cpsThreshold
+            $threshold | should not be $null
+            $threshold.Cpu.percentValue | should be $cputhreshold
+            $threshold.Memory.percentValue | should be $memorythreshold
+            $threshold.ConnectionsPerSecond.value | should be $cpsThreshold
+        }
+        it "Can adjust Memory DFW event threshold" {
+            $threshold = Set-NsxFirewallThreshold  -Memory $memorythreshold1
+            $threshold | should not be $null
+            
+            $threshold.Memory.percentValue | should be $memorythreshold1
+        }
+        it "Can adjust CPU DFW event threshold" {
+            $threshold = Set-NsxFirewallThreshold -Cpu $cputhreshold1
+            $threshold | should not be $null
+            $threshold.Cpu.percentValue | should be $cputhreshold1
+        }
+        it "Can adjust ConnectionsPerSecond DFW event thresholds" {
+            $threshold = Set-NsxFirewallThreshold -ConnectionsPerSecond $cpsThreshold1
+            $threshold | should not be $null
+            $threshold.ConnectionsPerSecond.Value | should be $cpsThreshold1
+        }
+
+        it "Can adjust Global Containers"{
+
+        }
+
+        it "Can adjust TCP Optimisation"{
+
+        }
+    }  
+}

--- a/tools/DiagramNSX/NsxObjectCapture.ps1
+++ b/tools/DiagramNSX/NsxObjectCapture.ps1
@@ -195,7 +195,7 @@ Get-Vm -server $connection.ViConnection| % {
 
 write-host "  Getting IP and MAC details from Spoofguard"
 Get-NsxSpoofguardPolicy -connection $connection | Get-NsxSpoofguardNic -connection $connection | % {
-    if $MacHash.ContainsKey($_.detectedmacAddress) {
+    if ($MacHash.ContainsKey($_.detectedmacAddress)) {
         write-warning "Duplicate MAC ($($_.detectedMacAddress) - $($_.nicname)) found.  Skipping NIC!"
     }
     else {


### PR DESCRIPTION
DFW Threshold command

- Set-NsxFirewallThreshold
   - Added integer maximums per internal sourcecode.
- Get-NsxFirewallThreshold
- Pester tests - Context added to DFW Tests
- Added to PSD manifest

MISC:

Updated help texts of some commands.

Output of Pester.

`SNIP

Context DFW Global options

    [+] Can adjust default DFW event threshold 216ms

SNIP`