### PR TITLE
Enhance security group effective membership cmdlet

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -284,7 +284,7 @@ FunctionsToExport = @(
     'Remove-NsxLoadBalancerVip',
     'Get-NsxSecurityPolicy',
     'Remove-NsxSecurityPolicy',
-    'Get-NsxSecurityGroupEffectiveMembers',
+    'Get-NsxSecurityGroupEffectiveMember',
     'Find-NsxWhereVMUsed',
     'Get-NsxBackingPortGroup',
     'Get-NsxBackingDVSwitch',
@@ -318,7 +318,11 @@ FunctionsToExport = @(
     'Add-NsxLicense',
     'Get-NsxLicense',
     'Get-NsxApplicableMember',
-    'Get-NsxSecurityGroupMemberTypes'
+    'Get-NsxSecurityGroupMemberTypes',
+    'Get-NsxSecurityGroupEffectiveVirtualMachine',
+    'Get-NsxSecurityGroupEffectiveIpAddress',
+    'Get-NsxSecurityGroupEffectiveMacAddress',
+    'Get-NsxSecurityGroupEffectiveVnic'
 )
 
 # Cmdlets to export from this module


### PR DESCRIPTION
Rename Get-NsxSecurityGroupEffectiveMember(s) to remove
plural

Removed static direct inclusion from Get-NsxSecurityGroupEffectiveMember output as it is misleading.

Added SecurityGroupId parameter

Added ReturnTypes parameter allowing limitation of specific
translation calls if required for performance

Added four wrapper functions
(Get-NsxSecurityGroupEffectiveVirtualMachine,
Get-NsxSecurityGroupEffectiveIpAddress,
Get-NsxSecurityGroupEffectiveMacAddress,
Get-NsxSecurityGroupEffectiveVnic
and enahanced output for human interaction

Intend for Get-NsxSecurityGroupEffectiveMember to be used
programatically, and the wrappers to be used by people interactively