### PR TITLE
Enhance get nsxfirewallrule

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21725,14 +21725,15 @@ function Get-NsxFirewallRule {
     #>
 
 
-    [CmdletBinding(DefaultParameterSetName="Section")]
+    [CmdletBinding(DefaultParameterSetName="Filter")]
 
     param (
 
         [Parameter (Mandatory=$true,ValueFromPipeline=$true,ParameterSetName="Section")]
             [ValidateNotNull()]
             [System.Xml.XmlElement]$Section,
-        [Parameter (Mandatory=$false, Position=1)]
+        [Parameter (Mandatory=$false, Position=1, ParameterSetName="Filter")]
+        [Parameter (Mandatory=$false, Position=1, ParameterSetName="Section")]
             [ValidateNotNullorEmpty()]
             [string]$Name,
         [Parameter (Mandatory=$true,ParameterSetName="RuleId")]

--- a/tests/integration/01.Environment.Tests.ps1
+++ b/tests/integration/01.Environment.Tests.ps1
@@ -37,6 +37,8 @@ Describe "Environment" -Tags "Environment" {
 
     it "Has hosts connected it can deploy to"{}
 
+    it "Has a running controller"{}
+
     BeforeAll {
 
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.


### PR DESCRIPTION
Added ability to retrieve firewall rules matching source/dest criteria.

Source/Dest can be IP or VM object, or Moref.

Updated default behaviour of -name filter to exercise parameter based filter rather than filtering on the client.  The former is more efficient.  If using section | get-nsxfirewallrule -name, the old client side filtering is still done to maintain backward compatibility.

Added tests for new functionality.