### PR TITLE
Adding NTP and TZ config cmdlets based on PR #127

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -295,6 +295,8 @@ FunctionsToExport = @(
     'Get-NsxManagerSsoConfig',
     'Get-NsxManagerVcenterConfig',
     'Get-NsxManagerTimeSettings',
+    'Set-NsxManagerTimeSettings',
+    'Clear-NsxManagerTimeSettings',
     'Get-NsxManagerSyslogServer',
     'Get-NsxManagerNetwork',
     'Get-NsxManagerBackup',

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -4929,14 +4929,6 @@ function Set-NsxManager {
 
     Param (
 
-        [Parameter (Mandatory=$True, ParameterSetName="Ntp")]
-            #NTP server for time synchronization..
-            [ValidateNotNullOrEmpty()]
-            [string]$NtpServer,
-        [Parameter (Mandatory=$False, ParameterSetName="Ntp")]
-            #Time Zone, default UTC.
-            [ValidateNotNullOrEmpty()]
-            [string]$TimeZone="UTC",
         [Parameter (Mandatory=$True, ParameterSetName="Syslog")]
             #Syslog server to which syslogs will be forwarded.
             [ValidateNotNullOrEmpty()]
@@ -4998,21 +4990,6 @@ function Set-NsxManager {
     [System.XML.XMLDocument]$xmlDoc = New-Object System.XML.XMLDocument
 
     switch ( $PsCmdlet.ParameterSetName ) {
-
-        "Ntp" {
-
-            [System.XML.XMLElement]$xmlRoot = $xmlDoc.CreateElement('timeSettings')
-            $xmlDoc.appendChild($xmlRoot) | out-null
-
-            [System.XML.XMLElement]$xmlNtpNode = $xmlDoc.CreateElement('ntpServer')
-            $xmlRoot.Appendchild($xmlNtpNode) | out-null
-
-            Add-XmlElement -xmlRoot $xmlNtpNode -xmlElementName "string" -xmlElementText $ntpServer.ToString()
-            Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "timezone" -xmlElementText $timeZone.ToString()
-
-            $uri = "/api/1.0/appliance-management/system/timesettings"
-            $method = "put"
-        }
 
         "Syslog" {
 
@@ -5256,6 +5233,128 @@ function Get-NsxManagerTimeSettings {
         Add-XmlElement -xmlRoot $xmlTimeSettings -xmlElementName "timezone" -xmlElementText $result.timezone
         $xmlTimeSettings
     }
+}
+
+function Set-NsxManagerTimeSettings {
+
+    <#
+    .SYNOPSIS
+    Configures -NtpServer and TimeZone settings for an existing NSX Manager appliance.
+
+    .DESCRIPTION
+    The NSX management plane is provided by NSX Manager, the centralized
+    network management component of NSX. It provides the single point of
+    configuration for NSX operations, and provides NSX's REST API.
+
+    The Set-NsxManagerTimeZone cmdlet allows configuration of the appliances
+    timezone related settings.
+
+    .EXAMPLE
+    Set-NsxManagerTimeSettings -NtpServer 0.pool.ntp.org -Timezone UTC
+
+    Configures NSX Manager NTP Server.
+
+    #>
+
+    Param (
+
+        [Parameter (Mandatory=$False)]
+            #NTP server for time synchronization..
+            [ValidateNotNullOrEmpty()]
+            [string[]]$NtpServer,
+        [Parameter (Mandatory=$False)]
+            #Time Zone, default UTC.
+            [ValidateNotNullOrEmpty()]
+            [string]$TimeZone="UTC",
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+
+    )
+
+    $uri = "/api/1.0/appliance-management/system/timesettings"
+    [System.Xml.XmlDocument]$Existing = Invoke-NsxRestMethod -Method get -uri $uri -Connection $Connection
+    #Api barfs if we set the time with the value we get from it.  And in a non intuitive way... sigh again...
+
+    $null = $Existing.timeSettings.RemoveChild((invoke-xpathquery -node $Existing -QueryMethod SelectSingleNode -query "child::timeSettings/datetime") )
+
+    If ( Invoke-XpathQuery -Node $Existing -QueryMethod SelectSingleNode -query "child::timeSettings") {
+        if ( $PSBoundParameters.ContainsKey("ntpserver")) {
+            if ( Invoke-XpathQuery -Node $Existing -QueryMethod SelectSingleNode -query "child::timeSettings/ntpServer" ) {
+
+                write-warning "Existing NTP servers are configured and will be retained.  Use Clear-NsxManagerTimeSettings to remove them."
+                #Api doesnt allow 'updates', so we have to save existing, then remove, then readd the union of old and new.
+                Clear-NsxManagerTimeSettings
+
+                foreach ($Server in $ntpserver) {
+                    if ( $Existing.timeSettings.ntpServer.string -notcontains $server ) {
+                        Add-XmlElement -xmlRoot $Existing.timeSettings.ntpServer -xmlElementName "string" -xmlElementText $server.ToString()
+                    }
+                }
+            }
+            else {
+                [System.XML.XMLElement]$xmlNtpNode = $Existing.CreateElement('ntpServer')
+                $Existing.timeSettings.Appendchild($xmlNtpNode) | out-null
+                foreach ($Server in $ntpserver) {
+                    Add-XmlElement -xmlRoot $xmlNtpNode -xmlElementName "string" -xmlElementText $server.ToString()
+                }
+            }
+        }
+        if ($PSBoundParameters.ContainsKey("TimeZone")) {
+            $Existing.timeSettings.timezone = $timeZone.ToString()
+        }
+
+        $uri = "/api/1.0/appliance-management/system/timesettings"
+        $null = Invoke-NsxRestMethod -Method put -body $Existing.timeSettings.outerXml -uri $uri -Connection $Connection
+        Get-NsxManagerTimeSettings
+    }
+    else {
+        throw "Unexpected response from API when querying existing time settings."
+    }
+}
+
+function Clear-NsxManagerTimeSettings {
+
+    <#
+    .SYNOPSIS
+    Removes NtpServer and TimeZone settings for an existing NSX Manager
+    appliance.
+
+    .DESCRIPTION
+    The NSX management plane is provided by NSX Manager, the centralized
+    network management component of NSX. It provides the single point of
+    configuration for NSX operations, and provides NSX's REST API.
+
+    The Remove-NsxManagerTimeSettings cmdlet allows an appliances existing timezone
+    related settings to be cleared.
+
+    .EXAMPLE
+    Remove-NsxManagerTimeSettings
+
+    UnConfigures NSX Manager NTP Server and TimeZone.
+
+    #>
+
+    Param (
+        [switch]$ClearTimeZone=$false,
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+    )
+
+    $Existing = Get-NsxManagerTimeSettings
+    if ( Invoke-XpathQuery -QueryMethod SelectSingleNode -Node $Existing -query "child::ntpServer") {
+        #API errors if you clear when there arent any existing NTP servers configured... sigh...
+        $uri = "/api/1.0/appliance-management/system/timesettings/ntp"
+        $null = Invoke-NsxRestMethod -Method delete -uri $uri -Connection $Connection
+    }
+
+    if ($ClearTimeZone ) {
+        $null = Set-NsxManagerTimeSettings -TimeZone UTC
+    }
+
 }
 
 function Get-NsxManagerSyslogServer {

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -1,0 +1,84 @@
+#PowerNSX Manager cmdlet tests.
+#Nick Bradford : nbradford@vmware.com
+
+#########################
+#Do not remove this - we need to ensure connection setup and module deps preload have occured.
+If ( -not $PNSXTestNSXManager ) {
+    Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
+}
+
+Describe "NSXManager" {
+
+    BeforeAll {
+
+        #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
+        #We load the mod and establish connection to NSX Manager here.
+
+        #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
+        import-module $pnsxmodule
+        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+
+
+        #Put any script scope variables you need to reference in your tests.
+        #For naming items that will be created in NSX, use a unique prefix
+        #pester_<testabbreviation>_<objecttype><uid>.  example:
+        $script:NTPServer1 = "1.1.1.1"
+        $script:NTPServer2 = "2.2.2.2"
+        $Script:TimeZone = "Australia/Melbourne"
+
+        #Try to preserve existing state...
+        $Script:PreExistingConfig = Get-NsxManagerTimeSettings
+    }
+
+    Context "Time" {
+
+        #Group related tests together.
+
+        it "Can get existing time configuration" {
+
+            $TimeConfig = Get-NsxManagerTimeSettings
+            $TimeConfig.datetime | should not be $null
+
+            #Not 100% on this, but I think tz always exists, and defaults to UTC.
+            $TimeConfig.timezone | should not be $null
+
+        }
+
+        it "Can clear existing NTP configuration" {
+            $TimeConfig = Clear-NsxManagerTimeSettings
+            $TimeConfig | should be $null
+            $GetTimeConfig = Get-NsxManagerTimeSettings
+            $GetTimeConfig.NtpServer | should be $null
+        }
+
+        it "Can configure NTP servers" {
+            $TimeConfig = Set-NsxManagerTimeSettings -NtpServer $NTPServer1, $NTPServer2
+            $TimeConfig.ntpserver | should not be $null
+            $GetTimeConfig = Get-NsxManagerTimeSettings
+            $GetTimeConfig.ntpserver.string -contains $NTPServer1 | should be $true
+            $GetTimeConfig.ntpserver.string -contains $NTPServer2 | should be $true
+        }
+
+        it "Can configure timezone configuration" {
+            $TimeConfig = Set-NsxManagerTimeSettings -TimeZone $TimeZone
+            $TimeConfig.timezone | should be $Timezone
+            $GetTimeConfig = Get-NsxManagerTimeSettings
+            $TimeConfig.timezone | should be $Timezone
+        }
+    }
+
+
+    AfterAll {
+        #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
+        #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
+        #We kill the connection to NSX Manager here.
+
+        if ($PreExistingConfig.ntpserver.string) {
+            Clear-NsxManagerTimeSettings
+            Set-NsxManagerTimeSettings -NtpServer $PreExistingConfig.ntpserver.string
+        }
+        Set-NsxManagerTimeSettings -TimeZone $PreExistingConfig.timezone
+
+        disconnect-nsxserver
+    }
+}


### PR DESCRIPTION
Modified initial NTP configuration by @lamw:
 - Moved to separate cmdlets (preferred direction for discrete functionality now)
 - Updated set- to handle existing config
 - Added Clear- to remove existing config
 - Added handling for multiple NTPservers in one command
 - ntpservers no longer mandatory (update only tz if required)
 - Added tests
