### PR TITLE
Enhance robustness of controller deployment

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5884,6 +5884,8 @@ function New-NsxController {
             if ( -not (($response.Headers.keys -contains "location") -and ($response.Headers["location"] -match "/api/2.0/vdn/controller/" )) ) {
                 throw "Controller deployment failed. $($response.content)"
             }
+#Todo : probably need to use the job id to check for status rather than regetting on the object...
+
             $controllerid = $response.Headers["location"] -replace "/api/2.0/vdn/controller/"
             $Controller = Get-NsxController -connection $connection -objectid $controllerId
             if ( -not ( Invoke-XpathQuery -QueryMethod SelectSingleNode -query "child::status" -Node $controller )) {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6052,7 +6052,6 @@ function Remove-NsxController {
             if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -activity "Remove Controller $objectId" }
             $null = invoke-nsxwebrequest -method "delete" -uri $URI -connection $connection
             if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -activity "Remove Controller $objectId" -completed }
-
         }
     }
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5922,6 +5922,9 @@ function New-NsxController {
                     }
 
                     $Controller = Get-Nsxcontroller -connection $connection -objectId ($controller.id)
+                    if ( -not ( Invoke-XpathQuery -QueryMethod SelectSingleNode -query "child::status" -Node $controller )) {
+                        throw "Controller deployment failed.  Status property not available on returned controller object.  Check NSX for more details on cause."
+                    }
                 }
                 if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress "Waiting for NSX controller to enter a running state. (Current state: $($Controller.Status))" -Completed }
             }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5856,7 +5856,7 @@ function New-NsxController {
                 $response = invoke-nsxwebrequest -method "post" -uri $URI -body $body -connection $connection
             }
             catch {
-                throw "Controller deployment failed. $($response.content)"
+                throw "Controller deployment failed. $_"
             }
             if ( -not (($response.Headers.keys -contains "location") -and ($response.Headers["location"] -match "/api/2.0/vdn/controller/" )) ) {
                 throw "Controller deployment failed. $($response.content)"


### PR DESCRIPTION
Attempt to address spurious errors thrown in New-NsxController if deployment fails.  This should resolve issue #2.  Note that this is a stop gap  - future will involve using the NSX jobs api to check for deployment status.