### PR TITLE
Get-NsxManagerCertificate

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -303,6 +303,7 @@ FunctionsToExport = @(
     'Get-NsxManagerBackup',
     'Get-NsxManagerComponentSummary',
     'Get-NsxManagerSystemSummary',
+    'Get-NsxManagerCertificate',
     'New-NsxServiceGroup',
     'Add-NsxServiceGroupMember',
     'Get-NsxServiceGroup',

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5150,10 +5150,7 @@ function Get-NsxManagerCertificate {
     [System.Xml.XmlDocument]$response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
 
     if ((Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $response -Query 'descendant::x509Certificates/x509certificate')) {
-        $certificates = $response.X509Certificates.x509certificate
-
-        $certificates
-
+        $response.X509Certificates.x509certificate
     }
 }
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5111,6 +5111,52 @@ function Set-NsxManager {
     Invoke-NsxRestMethod -Method $method -body $xmlRoot.outerXml -uri $uri -Connection $Connection
 }
 
+function Get-NsxManagerCertificate {
+
+    <#
+    .SYNOPSIS
+    Retrieves NSX Manager Certificates.
+
+    .DESCRIPTION
+    The NSX Manager is the central management component of VMware NSX for
+    vSphere.
+
+    Details of the SSL Certificate installed on the NSX Manager are required by
+    certain workflows within NSX
+
+    The Get-NsxManagerCertificate cmdlet retrieves the configured certificates
+    configured on the NSX Manager against which the command is run.
+
+    .EXAMPLE
+    Get-NsxManagerCertificate
+
+    Retreives the SSL Certificates from the connected NSX Manager
+
+    Get-NsxManagerCertificate | where { $_.isCa -eq "false" } | select sha1Hash
+
+    Retrieves the SSL Certificates SHA1 hash from the connected NSX Manager
+    #>
+
+
+    param (
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+    )
+
+    $URI = "/api/1.0/appliance-management/certificatemanager/certificates/nsx"
+
+    [System.Xml.XmlDocument]$response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+
+    if ((Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $response -Query 'descendant::x509Certificates/x509certificate')) {
+        $certificates = $response.X509Certificates.x509certificate
+
+        $certificates
+
+    }
+}
+
 function Get-NsxManagerSsoConfig {
 
     <#

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -44,6 +44,12 @@ Describe "NSXManager" {
 
         }
 
+        it "Can get configured SSL Certificates" {
+            $certificates = Get-NsxManagerCertificate
+            $( $certificates | measure ).count | should BeGreaterThan 0 
+            $certificates | should not be $null
+        }
+
         it "Can clear existing NTP configuration" {
             $TimeConfig = Clear-NsxManagerTimeSettings
             $TimeConfig | should be $null

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -44,12 +44,6 @@ Describe "NSXManager" {
 
         }
 
-        it "Can get configured SSL Certificates" {
-            $certificates = Get-NsxManagerCertificate
-            $( $certificates | measure ).count | should BeGreaterThan 0 
-            $certificates | should not be $null
-        }
-
         it "Can clear existing NTP configuration" {
             $TimeConfig = Clear-NsxManagerTimeSettings
             $TimeConfig | should be $null
@@ -73,6 +67,17 @@ Describe "NSXManager" {
         }
     }
 
+    Context "Certificate" {
+
+        #Group related tests together.
+
+        it "Can get configured SSL Certificates" {
+            $certificates = Get-NsxManagerCertificate
+            $( $certificates | measure ).count | should BeGreaterThan 0 
+            $certificates | should not be $null
+        }
+
+    }
 
     AfterAll {
         #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.


### PR DESCRIPTION
Added a cmdlet to retrieve the configured certificate of a connected NSX Manager. This is required as part of the workflow to add a secondary NSX Manager.