### PR TITLE
Update New-NSxFirewallRule to allow servicegroup to be specified

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -22270,7 +22270,7 @@ function New-NsxFirewallRule  {
             [ValidateNotNullOrEmpty()]
             [switch]$NegateDestination,
         [Parameter (Mandatory=$false)]
-            [ValidateScript ({ Validate-Service $_ })]
+            [ValidateScript ({ Validate-ServiceOrServiceGroup $_ })]
             [System.Xml.XmlElement[]]$Service,
         [Parameter (Mandatory=$false)]
             [string]$Comment="",

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -1017,6 +1017,8 @@ Describe "Distributed Firewall" {
             $rule.name | should be "pester_dfw_rule1"
         }
 
+        it "Can create a rule with a servicegroup specified as service"
+
         BeforeEach {
             #create new sections for each test.
 


### PR DESCRIPTION
update new-nsxfirewall so it accepts a servicegroup in the service parameter.