### PR TITLE
Modification for Universal Tags and Firewall Sections

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -22028,7 +22028,7 @@ function New-NsxFirewallSection  {
             [string]$scopeId="globalroot-0",
         [Parameter (Mandatory=$false)]
             #Marks the firewall section to be universal or not
-            [switch]$Universal
+            [switch]$Universal,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -19848,9 +19848,9 @@ function New-NsxSecurityTag {
         [Parameter (Mandatory=$false)]
             [string]$Description,
         [Parameter (Mandatory=$false)]
-            [switch]$Universal=$true,
+            #This marks the tag as a universal object within the constructs of NSX
+            [switch]$Universal,
         [Parameter (Mandatory=$False)]
-
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
             [PSCustomObject]$Connection=$defaultNSXConnection
@@ -19874,13 +19874,13 @@ function New-NsxSecurityTag {
         Add-XmlElement -xmlRoot $xmlnodes -xmlElementName "typeName" -xmlElementText "SecurityTag"
         Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "name" -xmlElementText $Name
 
-
         #Optional fields
         if ( $PsBoundParameters.ContainsKey('Description')) {
             Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "description" -xmlElementText "$Description"
         }
 
-        if ( $PsBoundParameters.ContainsKey('Universal')) {
+        if ($Universal) {
+            #Create the XML to mark the object as universal
             Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "isUniversal" -xmlElementText $Universal
         }
 
@@ -22027,7 +22027,8 @@ function New-NsxFirewallSection  {
             })]
             [string]$scopeId="globalroot-0",
         [Parameter (Mandatory=$false)]
-            [switch]$Universal=$true,
+            #Marks the firewall section to be universal or not
+            [switch]$Universal
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -22047,7 +22048,8 @@ function New-NsxFirewallSection  {
         Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "name" -xmlElementText $Name
 
         #Optional Fields
-        if ( $PsBoundParameters.ContainsKey('Universal')) {
+        if ($Universal) {
+          #Create XML for universal object
           Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "managedBy" -xmlElementText "universalroot-0"
         }
 


### PR DESCRIPTION
Modified the REST calls for Security Tags and Firewall Sections and
reduced the scopeid parameters in the Firewall Sections since universal
objects are placed below globalroot-0 now.

![image](https://cloud.githubusercontent.com/assets/6990206/24259546/cd5602ee-0fb6-11e7-8f2e-a103fe18f78d.png)

