### PR TITLE
Enable valid SSO credentials to be used to authenticate in Connect-NsxServer.

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -3800,45 +3800,50 @@ function Connect-NsxServer {
 
     $URI = "/api/1.0/appliance-management/global/info"
 
+    #Setup the connection object
+    $connection = new-object PSCustomObject
+    $Connection | add-member -memberType NoteProperty -name "Version" -value $null
+    $Connection | add-member -memberType NoteProperty -name "BuildNumber" -value $null
+
     #Test NSX connection
     try {
         $response = invoke-nsxrestmethod -cred $Credential -server $Server -port $port -protocol $Protocol -method "get" -uri $URI -ValidateCertificate:$ValidateCertificate
+
+        # try to populate version information
+
+        # NSX-v 6.2.3 changed the output of the following API from JSON to XML.
+        #
+        # /api/1.0/appliance-management/global/info"
+        #
+        # Along with the return JSON/XML change, the data structure also received a
+        # new base element named globalInfo.
+        #
+        # So what we do is try for the new format, and if it fails, lets default to
+        # the old JSON format.
+        if ( $response -as [System.Xml.XmlDocument] ) {
+            if ( Invoke-XpathQuery -QueryMethod SelectSingleNode -Node $response -query "child::globalInfo/versionInfo" ) {
+                $Connection.Version = $response.globalInfo.versionInfo.majorVersion + "." + $response.globalInfo.versionInfo.minorVersion + "." + $response.globalInfo.versionInfo.patchVersion
+                $Connection.BuildNumber = $response.globalInfo.versionInfo.BuildNumber
+            }
+        }
+        else {
+            if ( get-member -InputObject $response -MemberType NoteProperty -Name versionInfo ) {
+                $Connection.Version = $response.VersionInfo.majorVersion + "." + $response.VersionInfo.minorVersion + "." + $response.VersionInfo.patchVersion
+                $Connection.BuildNumber = $response.VersionInfo.BuildNumber
+            }
+        }
     }
     catch {
 
         #supression excep in event of 403.  Valid non local account credentias are not able to query the appliance-management API
         if ( $_ -match '403 : Forbidden|403 \(Forbidden\)') {
-            write-warning "A valid local admin account is required to access version information.  This error can be ignored if using SSO credentials to authenticate to NSX, however, appliance version information will not be available."
+            write-warning "A valid local admin account is required to access version information.  This warning can be ignored if using SSO credentials to authenticate to NSX, however, appliance version information will not be available in the connection object."
         }
         else {
             Throw "Unable to connect to NSX Manager at $Server.  $_"
         }
     }
-    $connection = new-object PSCustomObject
-    # NSX-v 6.2.3 changed the output of the following API from JSON to XML.
-    #
-    # /api/1.0/appliance-management/global/info"
-    #
-    # Along with the return JSON/XML change, the data structure also received a
-    # new base element named globalInfo.
-    #
-    # So what we do is try for the new format, and if it fails, lets default to
-    # the old JSON format.
-    $Connection | add-member -memberType NoteProperty -name "Version" -value $null
-    $Connection | add-member -memberType NoteProperty -name "BuildNumber" -value $null
-    try {
-        $Connection.Version = "$($response.globalInfo.versionInfo.majorVersion).$($response.globalInfo.versionInfo.minorVersion).$($response.globalInfo.versionInfo.patchVersion)"
-        $Connection.BuildNumber = $($response.globalInfo.versionInfo.BuildNumber)
-    }
-    catch {
-        try {
-            $Connection.Version = "$($response.VersionInfo.majorVersion).$($response.VersionInfo.minorVersion).$($response.VersionInfo.patchVersion)"
-            $Connection.BuildNumber = $response.VersionInfo.BuildNumber
-        }
-        catch {
-            write-warning "Unable to determine version information.  This may be due to a restriction in the rights the current user has to read the appliance-management API and may not represent an issue."
-        }
-    }
+
     $Connection | add-member -memberType NoteProperty -name "Credential" -value $Credential -force
     $connection | add-member -memberType NoteProperty -name "Server" -value $Server -force
     $connection | add-member -memberType NoteProperty -name "Port" -value $port -force

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -3806,8 +3806,8 @@ function Connect-NsxServer {
     }
     catch {
 
-        #supression excep in event of 403.  Valid non local account credentiasl are not able to query the appliance-management API
-        if ( $_ -match '403 : Forbidden') {
+        #supression excep in event of 403.  Valid non local account credentias are not able to query the appliance-management API
+        if ( $_ -match '403 : Forbidden|403 (Forbidden)') {
             write-warning "A valid local admin account is required to access version information.  This error can be ignored if using SSO credentials to authenticate to NSX, however, appliance version information will not be available."
         }
         else {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -3807,7 +3807,7 @@ function Connect-NsxServer {
     catch {
 
         #supression excep in event of 403.  Valid non local account credentias are not able to query the appliance-management API
-        if ( $_ -match '403 : Forbidden|403 (Forbidden)') {
+        if ( $_ -match '403 : Forbidden|403 \(Forbidden\)') {
             write-warning "A valid local admin account is required to access version information.  This error can be ignored if using SSO credentials to authenticate to NSX, however, appliance version information will not be available."
         }
         else {

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -1017,7 +1017,7 @@ Describe "Distributed Firewall" {
             $rule.name | should be "pester_dfw_rule1"
         }
 
-        it "Can create a rule with a servicegroup specified as service"
+        it "Can create a rule with a servicegroup specified as service"{}
 
         BeforeEach {
             #create new sections for each test.

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -26,8 +26,11 @@ Describe "NSXManager" {
         $script:NTPServer2 = "2.2.2.2"
         $Script:TimeZone = "Australia/Melbourne"
 
+        #This can fail if non-admin account is used.
         #Try to preserve existing state...
-        $Script:PreExistingConfig = Get-NsxManagerTimeSettings
+        # $Script:PreExistingConfig = Get-NsxManagerTimeSettings
+
+        #Todo : Work out how to use account details to trigger a skip if non-admin used....
     }
 
     Context "Time" {
@@ -73,10 +76,9 @@ Describe "NSXManager" {
 
         it "Can get configured SSL Certificates" {
             $certificates = Get-NsxManagerCertificate
-            $( $certificates | measure ).count | should BeGreaterThan 0 
+            $( $certificates | measure ).count | should BeGreaterThan 0
             $certificates | should not be $null
         }
-
     }
 
     AfterAll {
@@ -84,12 +86,18 @@ Describe "NSXManager" {
         #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
         #We kill the connection to NSX Manager here.
 
-        if ($PreExistingConfig.ntpserver.string) {
-            Clear-NsxManagerTimeSettings
-            Set-NsxManagerTimeSettings -NtpServer $PreExistingConfig.ntpserver.string
-        }
-        Set-NsxManagerTimeSettings -TimeZone $PreExistingConfig.timezone
-
+        # This can fail if a non-admin account is used.
+        # if ($PreExistingConfig.ntpserver.string) {
+        #     Clear-NsxManagerTimeSettings
+        #     Set-NsxManagerTimeSettings -NtpServer $PreExistingConfig.ntpserver.string
+        # }
+        # try {
+        #     #this can fail depending on credentials
+        #     Set-NsxManagerTimeSettings -TimeZone $PreExistingConfig.timezone
+        # }
+        # catch {
+        #     #do nothing
+        # }
         disconnect-nsxserver
     }
 }


### PR DESCRIPTION
Credentials passed to Connect-NsxServer previously needed to be the local admin account.  Attempting to use SSO credentials would cause Connect-NsxServer to fail due to use of certain NSX apis that are not accessible to SSO credentials.  

SSO credentials can now be used, but are still limited to needing to be Enterprise_Admin role.  

Thanks to @VirtualizeStuff for headsup on current limitations.  Expect further changes to address the restriction on roles.