### PR TITLE
Add full SSO credential support and deprecate direct NSX manager connections.

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -330,7 +330,8 @@ FunctionsToExport = @(
     'Set-NsxFirewallThreshold',
     'Get-NsxFirewallThreshold',
     'Add-NsxIpSetMember',
-    'Remove-NsxIpSetMember'
+    'Remove-NsxIpSetMember',
+    'Get-NsxUserRole'
 )
 
 # Cmdlets to export from this module

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -32,17 +32,18 @@ function Start-Test {
 
         #We allow the user to drop a connection details file with creds
         write-warning "No saved connection details found, prompting user."
-        $PNSXTestNSXManager = read-host "NSX Manager Ip/Name"
-        $PNSXTestDefMgrUsername = read-host "NSX Manager Username"
-        $PNSXTestDefMgrPassword = read-host "NSX Manager Password"
+        # $PNSXTestNSXManager = read-host "NSX Manager Ip/Name"
+        $PNSXTestVC = read-host "vCenter Server Ip/Name"
+        $PNSXTestDefMgrUsername = "admin"
+        $PNSXTestDefMgrPassword = read-host "NSX Manager admin password"
 
         ###
         #PowerShell Core has bug in ConvertFrom-SecureString that means we cant persist encrypted credentials to disk.
         #$PNSXTestDefMgrCred = Get-Credential -Message "NSX Manager Credentials" -UserName "admin"
         #$PNSXTestDefViCred = Get-Credential -message "vCenter Credentials" -UserName "administrator@vsphere.local"
 
-        $PNSXTestDefViUsername = read-host "vCenter Username"
-        $PNSXTestDefViPassword = read-host "vCenter Password"
+        $PNSXTestDefViUsername = read-host "SSO Ent_Admin username"
+        $PNSXTestDefViPassword = read-host "SSO Ent_Admin password"
         $PNSXTestDefMgrCred = New-Object System.Management.Automation.PSCredential $PNSXTestDefMgrUsername, ( $PNSXTestDefMgrPassword | ConvertTo-SecureString -AsPlainText -Force )
         $PNSXTestDefViCred = New-Object System.Management.Automation.PSCredential $PNSXTestDefViUsername, ( $PNSXTestDefViPassword | ConvertTo-SecureString -AsPlainText -Force )
 
@@ -54,7 +55,7 @@ function Start-Test {
         $decision = $Host.UI.PromptForChoice($message, $question, $ynchoices, 0)
         if ( $decision -eq 0 ) {
             [pscustomobject]$export = @{
-                "nsxm" = $PNSXTestNSXManager;
+                "vc" = $PNSXTestVC;
 
 
                 ###
@@ -86,11 +87,11 @@ function Start-Test {
             $_
         }
 
-        if ( -not ( $import.nsxm -and $import.nsxuser -and $import.nsxpwd -and $import.viuser -and $import.vipwd )) {
+        if ( -not ( $import.vc -and $import.nsxuser -and $import.nsxpwd -and $import.viuser -and $import.vipwd )) {
             throw "Import file does not contain required connection information.  Delete existing file and try again."
         }
 
-        $PNSXTestNSXManager = $import.nsxm
+        $PNSXTestVC = $import.vc
 
         ###
         #PowerShell Core has bug in ConvertFrom-SecureString that means we cant persist encrypted credentials to disk.

--- a/tests/integration/00.Module.Tests.ps1
+++ b/tests/integration/00.Module.Tests.ps1
@@ -1,9 +1,9 @@
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) { 
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
-} 
+}
 
-Describe "PowerNSX Module" { 
+Describe "PowerNSX Module" {
 
     it "The module loads" {
         import-module $pnsxmodule

--- a/tests/integration/01.Environment.Tests.ps1
+++ b/tests/integration/01.Environment.Tests.ps1
@@ -1,43 +1,49 @@
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
 Describe "Environment" -Tags "Environment" {
 
-     it "Establishes a default connection to NSX Manager" {
-        $global:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
-    }
-
-    it "Establishes a nondefault connection to NSX Manager" {
-        $global:Conn = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false -VIDefaultConnection:$false
+    it "Establishes a default PowerNSX Connection" {
+        # Using VI based SSO connection now.
+        $global:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
     }
 
     it "Can find a VI cluster to deploy to" {
         $global:cl = get-cluster | select -first 1
         $cl | should not be $null
+        ($cl | get-vmhost | ? { $_.ConnectionState -eq 'Connected'} | measure).count | should BeGreaterThan 0
         write-warning "Subsequent tests that deploy appliances will use cluster $cl"
     }
 
     it "Can find a VI Datastore to deploy to" {
         $global:ds = $cl | get-datastore | select -first 1
         $ds | should not be $null
+        $ds.FreeSpaceGB | should BeGreaterThan 1
         write-warning "Subsequent tests that deploy appliances will use datastore $ds"
+    }
+
+    it "Has a running controller"{
+        $controllers = Get-NSxController
+        $controllers | should not be $null
+        $controllers.status -contains 'RUNNING' | should be $true
+        ($controllers.status | sort-object -Unique | measure).count | should be 1
+    }
+
+    It "Has all clusters in healthy state" {
+        $status = $cl | Get-NsxClusterStatus
+        $status.status -contains 'GREEN' | should be $true
+        $status.status -contains 'RED' | should be $false
+        # $status.status -contains 'YELLOW' | should be $false
+        # $status.status -contains 'UNKNOWN' | should be $false
+
     }
 
     it "Destroys default NSX connection" {
         disconnect-nsxserver
         $DefaultNsxServer | should be $null
     }
-
-    it "Destroys non default connection" {
-        Remove-Variable -scope global -name "conn"
-        $conn | should be $null
-    }
-
-    it "Has hosts connected it can deploy to"{}
-
-    it "Has a running controller"{}
 
     BeforeAll {
 

--- a/tests/integration/02.LogicalSwitch.Tests.ps1
+++ b/tests/integration/02.LogicalSwitch.Tests.ps1
@@ -1,16 +1,16 @@
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) { 
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
-} 
+}
 
-Describe "Logical Switching" { 
+Describe "Logical Switching" {
 
-    BeforeAll { 
+    BeforeAll {
 
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
         #We load the mod and establish connection to NSX Manager here.
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:ls1_name = "pester_ls_ls1"
     }
 
@@ -21,19 +21,19 @@ Describe "Logical Switching" {
 
     it "Can create a logical switch" {
         Get-NsxTransportZone | select -first 1 | new-nsxlogicalswitch $ls1_name
-        get-nsxlogicalswitch $ls1_name | should not be null
+        get-nsxlogicalswitch $ls1_name | should not be $null
     }
 
     it "Can remove a logical switch"{
         get-nsxlogicalswitch $ls1_name | Remove-NsxLogicalSwitch -Confirm:$false
         get-nsxlogicalswitch $ls1_name | should be $null
-    } 
+    }
 
-    AfterAll { 
+    AfterAll {
 
         #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
         #We kill the connection to NSX Manager here.
-        disconnect-nsxserver 
+        disconnect-nsxserver
     }
 }
 

--- a/tests/integration/03.LogicalRouter.Tests.ps1
+++ b/tests/integration/03.LogicalRouter.Tests.ps1
@@ -1,5 +1,5 @@
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -11,7 +11,7 @@ Describe "Logical Routing" {
         #We load the mod, establish connection to NSX Manager and do any local variable definitions here
 
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for logical router appliance deployment"
 

--- a/tests/integration/04.Edge.Tests.ps1
+++ b/tests/integration/04.Edge.Tests.ps1
@@ -1,5 +1,5 @@
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -12,7 +12,7 @@ Describe "Edge" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for edge appliance deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -1,6 +1,6 @@
 
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -17,7 +17,7 @@ Describe "Distributed Firewall" {
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         write-host -ForegroundColor Green "Performing setup tasks for DFW tests"
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for edge appliance deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/06.Nat.Tests.ps1
+++ b/tests/integration/06.Nat.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,7 +31,7 @@ Describe "Edge NAT" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for nat edge deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/07.SslVpn.Tests.ps1
+++ b/tests/integration/07.SslVpn.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,7 +31,7 @@ Describe "sslvpn" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for sslvpn edge deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/08.Service.Tests.ps1
+++ b/tests/integration/08.Service.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,7 +31,7 @@ Describe "Services" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
 
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix

--- a/tests/integration/09.ServiceGroups.Tests.ps1
+++ b/tests/integration/09.ServiceGroups.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,7 +31,7 @@ Describe "ServiceGroups" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
 
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,8 +31,7 @@ Describe "IPSets" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
-
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix
         #pester_<testabbreviation>_<objecttype><uid>.  example:

--- a/tests/integration/11.SecurityGroups.Tests.ps1
+++ b/tests/integration/11.SecurityGroups.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,7 +31,7 @@ Describe "SecurityGroups" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for edge appliance deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -3,7 +3,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -16,7 +16,8 @@ Describe "NSXManager" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -DisableVIAutoConnect
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:adminConnection = Connect-NsxServer -NsxServer $DefaultNsxConnection.Server -Credential $PNSXTestDefMgrCred
 
 
         #Put any script scope variables you need to reference in your tests.
@@ -26,11 +27,99 @@ Describe "NSXManager" {
         $script:NTPServer2 = "2.2.2.2"
         $Script:TimeZone = "Australia/Melbourne"
 
+        #SSO account used to test different level permissions.  MUST BE PRECREATED with at least vsphere R/O rights. (because there is no SSO API to do this automatically. GGGGGGGRRRRRRRRRRR)
+        $Script:TestSSOAccount = "powernsx_test@vsphere.local"
+        $Script:TestSSOPassword = "VMware1!"
+
         #This can fail if non-admin account is used.
         #Try to preserve existing state...
         # $Script:PreExistingConfig = Get-NsxManagerTimeSettings
 
-        #Todo : Work out how to use account details to trigger a skip if non-admin used....
+        #Test if required test SSO account exists in VC
+        try {
+            $dummyconn = Connect-VIServer $PNSXTestVC -NotDefault -username $TestSSOAccount -Password $TestSSOPassword -ErrorAction Stop
+            $Global:SkipSSOTests = $false
+        }
+        catch {
+            write-warning "Unable to authenticate to vCenter using test SSO account.  Please precreate $TestSSOAccount and grant at least R/O vCenter Inventory permissions.  SSO credential tests will be skipped."
+            $Global:SkipSSOTests = $True
+        }
+
+        $role = Get-NsxUserRole $PNSXTestDefViCred.Username
+        if ( $role.role -eq 'super_user') {
+            $Script:IsSuperUser = $true
+        }
+        else {
+            write-warning "Skipping tests requiring super_user (admin) credentials."
+            $Script:IsSuperUser = $false
+        }
+    }
+
+    Context "Basic Connect" {
+
+        #Connect-NsxServer tests
+        it "Can connect directly to NSX server using admin account - legacy mode" {
+            $NSXManager = $DefaultNsxConnection.Server
+            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+            $DirectConn | should not be $null
+            $DirectConn.Version | should not be $null
+            $DirectConn.BuildNumber | should not be $null
+            $DirectConn.ViConnection | should not be $null
+        }
+
+        it "Can connect directly to NSX server using Ent_Admin SSO account" {
+            $NSXManager = $DefaultNsxConnection.Server
+            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+            $DirectConn | should not be $null
+            $DirectConn.Version | should be $null
+            $DirectConn.BuildNumber | should be $null
+        }
+
+    }
+
+    Context "Restricted Role Connect" {
+
+        BeforeEach {
+            #ensure the NSX user account is removed.
+            try {
+                $result = Invoke-NsxRestMethod -method delete -uri "/api/2.0/services/usermgmt/role/$TestSSOAccount"
+            }
+            catch {
+                #Do nothing
+            }
+        }
+
+        It "Can connect using vCenter using Auditor SSO account" {
+
+            #Create auditor role xml
+            $xmlDoc = New-Object System.Xml.XmlDocument
+            $ace = $xmlDoc.CreateElement("accessControlEntry")
+            $xmlDoc.AppendChild($ace) | out-null
+
+            $roleElem = $xmlDoc.CreateElement("role")
+            $roleNode = $xmlDoc.CreateTextNode("auditor")
+            $ace.AppendChild($roleElem) | out-null
+            $roleElem.AppendChild($roleNode) | out-null
+
+            $resourceElem = $xmlDoc.CreateElement("resource")
+            $resourceIdElem = $xmlDoc.CreateElement("resourceId")
+            $resourceNode = $xmlDoc.CreateTextNode("globalroot-0")
+            $ace.AppendChild($resourceElem) | out-null
+            $resourceElem.AppendChild($resourceIdElem) | out-null
+            $resourceIdElem.AppendChild($resourceNode) | out-null
+
+            #make test user auditor
+            $result = Invoke-NsxRestMethod -method post -uri "/api/2.0/services/usermgmt/role/$TestSSOAccount" -body $ace.outerxml -connection $adminConnection
+
+            $testconn = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -DefaultConnection:$false
+
+            $testConn | should not be $null
+            $testConn.version | should not be $null
+            $testConn.BuildNumber | should not be $null
+            $testConn.VIConnection | should not be $null
+
+        }
+
     }
 
     Context "Time" {
@@ -39,7 +128,7 @@ Describe "NSXManager" {
 
         it "Can get existing time configuration" {
 
-            $TimeConfig = Get-NsxManagerTimeSettings
+            $TimeConfig = Get-NsxManagerTimeSettings -connection $adminConnection
             $TimeConfig.datetime | should not be $null
 
             #Not 100% on this, but I think tz always exists, and defaults to UTC.
@@ -48,14 +137,14 @@ Describe "NSXManager" {
         }
 
         it "Can clear existing NTP configuration" {
-            $TimeConfig = Clear-NsxManagerTimeSettings
+            $TimeConfig = Clear-NsxManagerTimeSettings -connection $adminConnection
             $TimeConfig | should be $null
             $GetTimeConfig = Get-NsxManagerTimeSettings
             $GetTimeConfig.NtpServer | should be $null
         }
 
         it "Can configure NTP servers" {
-            $TimeConfig = Set-NsxManagerTimeSettings -NtpServer $NTPServer1, $NTPServer2
+            $TimeConfig = Set-NsxManagerTimeSettings -NtpServer $NTPServer1, $NTPServer2 -connection $adminConnection
             $TimeConfig.ntpserver | should not be $null
             $GetTimeConfig = Get-NsxManagerTimeSettings
             $GetTimeConfig.ntpserver.string -contains $NTPServer1 | should be $true
@@ -63,7 +152,7 @@ Describe "NSXManager" {
         }
 
         it "Can configure timezone configuration" {
-            $TimeConfig = Set-NsxManagerTimeSettings -TimeZone $TimeZone
+            $TimeConfig = Set-NsxManagerTimeSettings -TimeZone $TimeZone -connection $adminConnection
             $TimeConfig.timezone | should be $Timezone
             $GetTimeConfig = Get-NsxManagerTimeSettings
             $TimeConfig.timezone | should be $Timezone
@@ -75,7 +164,7 @@ Describe "NSXManager" {
         #Group related tests together.
 
         it "Can get configured SSL Certificates" {
-            $certificates = Get-NsxManagerCertificate
+            $certificates = Get-NsxManagerCertificate -connection $adminConnection
             $( $certificates | measure ).count | should BeGreaterThan 0
             $certificates | should not be $null
         }

--- a/tests/integration/13.DFWGlobalOptions.Tests.ps1
+++ b/tests/integration/13.DFWGlobalOptions.Tests.ps1
@@ -1,10 +1,10 @@
 #PowerNSX Test template.
 #Nick Bradford : nbradford@vmware.com
 
-#Because PowerNSX is an API consumption tool, its test framework is limited to 
+#Because PowerNSX is an API consumption tool, its test framework is limited to
 #exercising cmdlet functionality against a functional NSX and vSphere API
 #If you disagree with this approach - feel free to start writing mocks for all
-#potential API reponses... :) 
+#potential API reponses... :)
 
 #In the meantime, the test format is not as elegant as normal TDD, but Ive made some effort to get close to this.
 #Each functional area in NSX should have a separate test file.
@@ -18,26 +18,25 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) { 
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
-} 
+}
 
-Describe "DFW Global Properties" { 
+Describe "DFW Global Properties" {
 
-    BeforeAll { 
+    BeforeAll {
 
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
         #We load the mod and establish connection to NSX Manager here.
-       
+
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
-        $script:Conn = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false -VIDefaultConnection:$false
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         # Threshold Variables
         $script:cpuThreshold = "75"
         $script:cpuThreshold1 = "85"
         $script:memoryThreshold = "75"
-        $script:memoryThreshold1 = "85" 
+        $script:memoryThreshold1 = "85"
         $script:cpsThreshold = "125000"
         $script:cpsThreshold1 = "200000"
         $script:cpsDefault = "100000"
@@ -46,14 +45,14 @@ Describe "DFW Global Properties" {
 
     }
 
-    AfterAll { 
+    AfterAll {
         #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
         #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
         #We kill the connection to NSX Manager here.
-        
+
         #TODO: This should take existing and honour it on finish
         Set-NsxFirewallThreshold -Cpu 100 -Memory 100 -ConnectionsPerSecond 100000 | out-null
-        disconnect-nsxserver 
+        disconnect-nsxserver
     }
 
     BeforeEach {
@@ -83,7 +82,7 @@ Describe "DFW Global Properties" {
         it "Can adjust Memory DFW event threshold" {
             $threshold = Set-NsxFirewallThreshold  -Memory $memorythreshold1
             $threshold | should not be $null
-            
+
             $threshold.Memory.percentValue | should be $memorythreshold1
         }
         it "Can adjust CPU DFW event threshold" {
@@ -104,5 +103,5 @@ Describe "DFW Global Properties" {
         it "Can adjust TCP Optimisation"{
 
         }
-    }  
+    }
 }

--- a/tests/integration/14.Universal.IpSets.Tests.ps1
+++ b/tests/integration/14.Universal.IpSets.Tests.ps1
@@ -18,7 +18,7 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) {
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
 }
 
@@ -31,8 +31,7 @@ Describe "Universal Object Support" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
-        # $script:Conn = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false -VIDefaultConnection:$false
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         # $script:cl = get-cluster | select -first 1
         # write-warning "Using cluster $cl for clustery stuff"
         # $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/99.TestTemplate.ps1
+++ b/tests/integration/99.TestTemplate.ps1
@@ -1,10 +1,10 @@
 #PowerNSX Test template.
 #Nick Bradford : nbradford@vmware.com
 
-#Because PowerNSX is an API consumption tool, its test framework is limited to 
+#Because PowerNSX is an API consumption tool, its test framework is limited to
 #exercising cmdlet functionality against a functional NSX and vSphere API
 #If you disagree with this approach - feel free to start writing mocks for all
-#potential API reponses... :) 
+#potential API reponses... :)
 
 #In the meantime, the test format is not as elegant as normal TDD, but Ive made some effort to get close to this.
 #Each functional area in NSX should have a separate test file.
@@ -18,37 +18,36 @@
 
 #########################
 #Do not remove this - we need to ensure connection setup and module deps preload have occured.
-If ( -not $PNSXTestNSXManager ) { 
+If ( -not $PNSXTestVC ) {
     Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
-} 
+}
 
-Describe "Logical Thingy" { 
+Describe "Logical Thingy" {
 
-    BeforeAll { 
+    BeforeAll {
 
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
         #We load the mod and establish connection to NSX Manager here.
-       
+
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
-        $script:Conn = Connect-NsxServer -Server $PNSXTestNSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false -VIDefaultConnection:$false
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefMgrCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for clustery stuff"
         $script:ds = $cl | get-datastore | select -first 1
         write-warning "Using datastore $ds for datastorey stuff"
 
-        #Put any script scope variables you need to reference in your tests.  
-        #For naming items that will be created in NSX, use a unique prefix 
-        #pester_<testabbreviation>_<objecttype><uid>.  example: 
+        #Put any script scope variables you need to reference in your tests.
+        #For naming items that will be created in NSX, use a unique prefix
+        #pester_<testabbreviation>_<objecttype><uid>.  example:
         $script:mynsxthing = "pester_lt_thing1"
     }
 
-    Context "Something interesting" { 
+    Context "Something interesting" {
 
         #Group related tests together.
 
-        it "Can do something" { 
+        it "Can do something" {
 
             #do something and then make an assertion about what it should be
             $thing = new-nsxthingy $mynsxthing
@@ -69,12 +68,12 @@ Describe "Logical Thingy" {
         ...
     }
 
-    AfterAll { 
+    AfterAll {
         #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
         #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.
         #We kill the connection to NSX Manager here.
 
-        disconnect-nsxserver 
+        disconnect-nsxserver
         Remove-Variable -scope global -name "conn"
     }
 }


### PR DESCRIPTION
Resolves issue #5 and addresses additional functionality raised in #75.  Also addresses limitations of recently introduced SSO code that prevents retrieval of version/build number.

This CHANGES the preferred method of Connect-NsxServer usage to utilise connectivity to vCenter to determine NSX endpoint rather than requiring the user to specify the NSX server endpoint.

Legacy behaviour continues to be supported, but is deprecated and will be removed (replaced by explicit -NSXServer parameter if direct connectivity is required) in a subsequent version.

