### PR TITLE
Cherry Pick @virtualizestuff: Added additional check to ensure PSversion is 5.1+

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -67,7 +67,7 @@ Function _init {
     #PSEdition property does not exist pre v5.  We need to do a few things in
     #exported functions to workaround some limitations of core edition, so we export
     #the global PNSXPSTarget var to reference if required.
-    if ( $PSVersionTable.PSVersion.Major -ge 5) {
+    if ( ($PSVersionTable.PSVersion.Major -ge 5) -and ($PSVersionTable.PSVersion.Minor -ge 1)) {
         $script:PNsxPSTarget = $PSVersionTable.PSEdition
     }
     else {


### PR DESCRIPTION
As version 5 of Powershell on Windows 7 doesnt contain a PSEdition in the PSVersiontable. 