### PR TITLE
Get-NsxApplicablePolicy Function

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -22312,6 +22312,69 @@ function Add-NsxServiceGroupMember {
     end {}
 }
 
+function Get-NsxApplicablePolicy {
+
+    <#
+    .SYNOPSIS
+    Query Security Policies Mapped to a Security Group
+
+    .DESCRIPTION
+    You can retrieve the security policies mapped to a security group. The list is sorted based on the precedence
+    of security policy precedence in descending order. The security policy with the highest precedence (highest
+    numeric value) is the first entry (index = 0) in the list.
+
+    .EXAMPLE
+    PS C:\> Get-NsxApplicablePolicy -SecurityGroup (Get-NsxSecurityGroup -name "SG_Test").objectId 
+
+    #>
+
+    [CmdLetBinding(DefaultParameterSetName="securitygroup")]
+
+    param (
+
+        [Parameter (Mandatory=$true,ParameterSetName="securitygroup",Position=1)]
+        [ValidateScript( { Validate-SecurityTag $_ })]   
+            #Query SecurityGroup by objectId
+            [string]$SecurityGroup,
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+
+    )
+
+    begin {}
+
+    process {
+
+        
+        if ( $PSCmdlet.ParameterSetName -eq "securitygroup") {
+            $URI = "/api/2.0/services/policy/securitygroup/$SecurityGroup/securitypolicies"
+        }
+        try {
+            $response = Invoke-NsxRestMethod -Uri $Uri -method Get -connection $connection
+        }
+        catch {
+            throw "Failed retreiving applicable polcies.  $_"
+        }
+        if ( !(Invoke-XpathQuery -QueryMethod SelectSingleNode -Node $response -query "child::securityPolicies").IsEmpty ) {
+            try {
+                if ( Invoke-XpathQuery -QueryMethod SelectSingleNode -Node $response -query "child::securityPolicies" ) {
+                    $response.securityPolicies.securityPolicy
+                }
+            }
+            catch {
+                throw "Content returned from NSX API could not be parsed as an applicable policy XML."
+            }
+        }
+        else {
+            throw "No Content returned from NSX API call."
+        }
+    }
+
+    end {}
+}
+
 function Get-NsxApplicableMember {
 
     <#

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -22333,7 +22333,6 @@ function Get-NsxApplicablePolicy {
     param (
 
         [Parameter (Mandatory=$true,ParameterSetName="securitygroup",Position=1)]
-        [ValidateScript( { Validate-SecurityTag $_ })]   
             #Query SecurityGroup by objectId
             [string]$SecurityGroup,
         [Parameter (Mandatory=$False)]


### PR DESCRIPTION
You can retrieve the security policies mapped to a security group. The list is sorted based on the precedence
of security policy precedence in descending order. The security policy with the highest precedence (highest
numeric value) is the first entry (index = 0) in the list.

Leveraging the following API call

- GET https://NSX-Manager-IP-Address/api/2.0/services/policy/securitygroup/securitygroupId/securitypolicies