### PR TITLE
New nsxfirewallrule rawservices

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -2392,7 +2392,6 @@ Function Validate-FirewallRuleService {
         # it through validation to stop doing stupid stuff like trying to pass
         # about logical switch or IP Set through to here.
         { $argument -is [System.Xml.XmlElement]} {
-            write-host "Found an xml document"
             try {
                 Validate-Service -argument $argument
             }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -2387,30 +2387,10 @@ Function Validate-FirewallRuleService {
             $true
             break
         }
-        # If an single xml element object has been provide, like from the output
-        # of Get-NsxService HTTP, or Get-NsxServiceGroup Heartbeat then we run
-        # it through validation to stop doing stupid stuff like trying to pass
-        # about logical switch or IP Set through to here.
-        { $argument -is [System.Xml.XmlElement]} {
-            try {
-                Validate-Service -argument $argument
-            }
-            catch {
-                try {
-                    Validate-ServiceGroup -argument $argument
-                }
-                catch {
-                    throw "Invalid Service or Service Group specific"
-                }
-            }
-            $true
-            break
-        }
-        # Alternatively if a collection of objects is return, like that is
-        # returned from Get-NsxService -match "HTTP", this will evaluate each
-        # item in the collection of objects and make sure each one is a valid
-        # service or service group to stop doing stupid stuff (read above)
-        { $argument -is [System.Object]} {
+        # If an single xml element object or a collection of objects have been provide,
+        # then we run it through validation to stop doing stupid stuff like trying to pass
+        # a logical switch or IP Set through to here.
+        { ($argument -is [System.Xml.XmlElement]) -or ($argument -is [System.Object])} {
             foreach ( $item in $argument ) {
                 try {
                     Validate-Service -argument $item
@@ -2420,7 +2400,7 @@ Function Validate-FirewallRuleService {
                         Validate-ServiceGroup -argument $item
                     }
                     catch {
-                        throw "Invalid Service or Service Group specific"
+                        throw "Invalid Service or Service Group specified"
                     }
                 }
             }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -23253,20 +23253,6 @@ function New-NsxFirewallRule  {
         }
 
         #Services
-        # if ( $service) {
-        #     [System.XML.XMLElement]$xmlServices = $XMLDoc.CreateElement("services")
-        #     #Iterate the services passed and build service nodes.
-        #     $xmlRule.appendChild($xmlServices) | out-null
-        #     foreach ( $serviceitem in $service ) {
-
-        #         #Services
-        #         [System.XML.XMLElement]$xmlService = $XMLDoc.CreateElement("service")
-        #         $xmlServices.appendChild($xmlService) | out-null
-        #         Add-XmlElement -xmlRoot $xmlService -xmlElementName "value" -xmlElementText $serviceItem.objectId
-
-        #     }
-        # }
-
         if ( $service ) {
             $xmlservices = New-NsxServiceNode -itemType "service" -itemlist $service -xmlDoc $xmlDoc
             $xmlRule.appendChild($xmlservices) | out-null

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -2382,7 +2382,7 @@ Function Validate-FirewallRuleService {
                     throw "Invalid protocol specified"
                 }
             } elseif ( $Script:AllValidServices -notcontains $argument ) {
-                throw "blah blah Invalid protocol specified"
+                throw "Invalid protocol specified"
             }
             $true
             break

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21203,33 +21203,6 @@ function Remove-NsxIpSetMember  {
     IP Range: (eg, 1.2.3.4-1.2.3.10)
     IP Subnet: (eg, 1.2.3.0/24)
 
-    .EXAMPLE
-    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 3.3.3.3
-
-    Removes the address 3.3.3.3 and 3.3.3.3/32 from the given NSX IPSet
-
-    .EXAMPLE
-    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 3.3.3.3/32
-
-    Removes the address 3.3.3.3 and 3.3.3.3/32 from the given NSX IPSet
-
-    .EXAMPLE
-    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 10.0.0.0/8
-
-    Removes the network 10.0.0.0/8 from the given NSX IPSet
-
-    .EXAMPLE
-    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember
-    -IPAddress 192.168.1.1-192.168.1.254
-
-    Removes the range 192.168.1.1-192.168.1.254 from the given NSX IPSet
-
-    .EXAMPLE
-    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember
-    -IPAddress 3.3.3.3,10.0.0.0/8,192.168.1.1-192.168.1.254
-
-    Removes the given IP Addresses, Networks and Ranges from the NSX IPSet
-
     #>
 
     [CmdletBinding()]
@@ -21264,27 +21237,12 @@ function Remove-NsxIpSetMember  {
         [system.collections.arraylist]$ValCollection = $_ipset.value -split ","
         $modified = $false
         foreach ( $value in $IPAddress ) {
-            # An IPSET allows the users to enter a host as either 1.1.1.1 or
-            # 1.1.1.1/32. So if the users specifies that they want to remove
-            # 1.1.1.1 we need to look for both 1.1.1.1 AND 1.1.1.1/32 to remove..
-            if ($value -match "/|-") {
-                if ( -not ( $valcollection -contains $value )) {
-                    write-warning "$Value not a member of IPSet $($ipset.name)"
-                }
-                else {
-                    $modified = $true
-                    $ValCollection.Remove($value)
-                }
+            if ( -not ( $valcollection -contains $value )) {
+                write-warning "$Value $value not a member of IPSet $($ipset.name)"
             }
             else {
-                if ( ( -not ( $valcollection -contains $value ) ) -and ( -not ( $valcollection -contains "$($value)/32" ) ) ) {
-                    write-warning "$Value not a member of IPSet $($ipset.name)"
-                }
-                else {
-                    $modified = $true
-                    $ValCollection.Remove($value)
-                    $ValCollection.Remove("$($value)/32")
-                }
+                $modified = $true
+                $ValCollection.Remove($value)
             }
         }
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21138,6 +21138,33 @@ function Remove-NsxIpSetMember  {
     IP Range: (eg, 1.2.3.4-1.2.3.10)
     IP Subnet: (eg, 1.2.3.0/24)
 
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 3.3.3.3
+
+    Removes the address 3.3.3.3 and 3.3.3.3/32 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 3.3.3.3/32
+
+    Removes the address 3.3.3.3 and 3.3.3.3/32 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 10.0.0.0/8
+
+    Removes the network 10.0.0.0/8 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember
+    -IPAddress 192.168.1.1-192.168.1.254
+
+    Removes the range 192.168.1.1-192.168.1.254 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember
+    -IPAddress 3.3.3.3,10.0.0.0/8,192.168.1.1-192.168.1.254
+
+    Removes the given IP Addresses, Networks and Ranges from the NSX IPSet
+
     #>
 
     [CmdletBinding()]
@@ -21172,12 +21199,27 @@ function Remove-NsxIpSetMember  {
         [system.collections.arraylist]$ValCollection = $_ipset.value -split ","
         $modified = $false
         foreach ( $value in $IPAddress ) {
-            if ( -not ( $valcollection -contains $value )) {
-                write-warning "$Value $value not a member of IPSet $($ipset.name)"
+            # An IPSET allows the users to enter a host as either 1.1.1.1 or
+            # 1.1.1.1/32. So if the users specifies that they want to remove
+            # 1.1.1.1 we need to look for both 1.1.1.1 AND 1.1.1.1/32 to remove..
+            if ($value -match "/|-") {
+                if ( -not ( $valcollection -contains $value )) {
+                    write-warning "$Value not a member of IPSet $($ipset.name)"
+                }
+                else {
+                    $modified = $true
+                    $ValCollection.Remove($value)
+                }
             }
             else {
-                $modified = $true
-                $ValCollection.Remove($value)
+                if ( ( -not ( $valcollection -contains $value ) ) -and ( -not ( $valcollection -contains "$($value)/32" ) ) ) {
+                    write-warning "$Value not a member of IPSet $($ipset.name)"
+                }
+                else {
+                    $modified = $true
+                    $ValCollection.Remove($value)
+                    $ValCollection.Remove("$($value)/32")
+                }
             }
         }
 

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -1044,12 +1044,12 @@ Describe "DFW" {
             $rule.sources | should be $null
             $rule.destinations | should be $null
             @($rule.services.service).count | should be 6
-            (($rule.services.service | Where-Object { $_.protocolName -eq $rawService1 }) | measure).count | should Be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice2 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice2 -split "/")[1] ) }) | measure).count | should be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }) | measure).count | should be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice4 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice4 -split "/")[1] ) }) | measure).count | should be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq $rawService5) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) }) | measure).count | should be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq $rawService6) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) }) | measure).count | should be 1
+            @($rule.services.service | Where-Object { $_.protocolName -eq $rawService1 }).count | should Be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice2 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice2 -split "/")[1] ) }).count | should be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }).count | should be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice4 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice4 -split "/")[1] ) }).count | should be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq $rawService5) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) }).count | should be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq $rawService6) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) }).count | should be 1
             @($rule.appliedToList.appliedto).count | should be 1
             $rule.appliedToList.appliedTo.Name | should be "DISTRIBUTED_FIREWALL"
             $rule.appliedToList.appliedTo.Value | should be "DISTRIBUTED_FIREWALL"
@@ -1088,11 +1088,10 @@ Describe "DFW" {
             @($rule.destinations.destination).count | should be 1
             @($rule.appliedToList.appliedTo).count | should be 1
             @($rule.services.service).count | should be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }) | measure).count | should be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }).count | should be 1
             $rule.sources.source.name | should be $testVmName1
             $rule.destinations.destination.name | should be $testVmName2
             $rule.appliedToList.appliedTo.name | should be $testVmName1
-            $rule.services.service.name | should be $testService1.Name
             $rule.name | should be "pester_dfw_rule1"
             $rule.action | should be allow
             $rule.disabled | should be "false"
@@ -1374,18 +1373,16 @@ Describe "DFW" {
             $rule.destinations | should beoftype System.Xml.XmlElement
             $rule.appliedToList | should beoftype System.Xml.XmlElement
             @($rule.services.service).count | should be 4
-            $rule.services.service | Where-Object { $_.Name -eq $TestServiceName1 } | should be 1
-            $rule.services.service | Where-Object { $_.Name -eq $TestServiceName2 } | should be 1
-            (($rule.services.service | Where-Object { $_.protocolName -eq $rawService1 }) | measure).count | should be 1
-            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }) | measure).count | should be 1
+            @($rule.services.service | Where-Object { $_.Name -eq $TestServiceName1 }).count | should be 1
+            @($rule.services.service | Where-Object { $_.Name -eq $TestServiceName2 }).count | should be 1
+            @($rule.services.service | Where-Object { $_.protocolName -eq $rawService1 }).count | should be 1
+            @($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }).count | should be 1
             @($rule.appliedToList.appliedTo).count | should be 2
             @($rule.destinations.destination).count | should be 2
             $sortedNames = ( @($testvm1.name, $testvm2.name) | Sort-Object)
-            $sortedServiceNames = ( @($TestService1.name, $TestService2.name) | Sort-Object )
             $rule.sources.source.name | sort-object | should be $sortedNames
             $rule.destinations.destination.name | sort-object | should be $sortedNames
             $rule.appliedToList.appliedTo.name  | sort-object | should be $sortedNames
-            $rule.services.service.name  | sort-object | should be $sortedServiceNames
             $rule.name | should be "pester_dfw_rule1"
             $rule.action | should be allow
             $rule.disabled | should be "false"

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -1044,12 +1044,12 @@ Describe "DFW" {
             $rule.sources | should be $null
             $rule.destinations | should be $null
             @($rule.services.service).count | should be 6
-            $rule.services.service | Where-Object { $_.protocolName -eq $rawService1 } | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice2 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice2 -split "/")[1] ) } | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) } | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice4 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice4 -split "/")[1] ) } | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq $rawService5) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) } | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq $rawService6) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) } | should be 1
+            (($rule.services.service | Where-Object { $_.protocolName -eq $rawService1 }) | measure).count | should Be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice2 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice2 -split "/")[1] ) }) | measure).count | should be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }) | measure).count | should be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice4 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice4 -split "/")[1] ) }) | measure).count | should be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq $rawService5) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) }) | measure).count | should be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq $rawService6) -and ( !($_ | get-member -name destinationport -Membertype Properties ) ) }) | measure).count | should be 1
             @($rule.appliedToList.appliedto).count | should be 1
             $rule.appliedToList.appliedTo.Name | should be "DISTRIBUTED_FIREWALL"
             $rule.appliedToList.appliedTo.Value | should be "DISTRIBUTED_FIREWALL"
@@ -1088,7 +1088,7 @@ Describe "DFW" {
             @($rule.destinations.destination).count | should be 1
             @($rule.appliedToList.appliedTo).count | should be 1
             @($rule.services.service).count | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) } | should be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }) | measure).count | should be 1
             $rule.sources.source.name | should be $testVmName1
             $rule.destinations.destination.name | should be $testVmName2
             $rule.appliedToList.appliedTo.name | should be $testVmName1
@@ -1376,8 +1376,8 @@ Describe "DFW" {
             @($rule.services.service).count | should be 4
             $rule.services.service | Where-Object { $_.Name -eq $TestServiceName1 } | should be 1
             $rule.services.service | Where-Object { $_.Name -eq $TestServiceName2 } | should be 1
-            $rule.services.service | Where-Object { $_.protocolName -eq $rawService1 } | should be 1
-            $rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) } | should be 1
+            (($rule.services.service | Where-Object { $_.protocolName -eq $rawService1 }) | measure).count | should be 1
+            (($rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) }) | measure).count | should be 1
             @($rule.appliedToList.appliedTo).count | should be 2
             @($rule.destinations.destination).count | should be 2
             $sortedNames = ( @($testvm1.name, $testvm2.name) | Sort-Object)

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -1341,7 +1341,7 @@ Describe "DFW" {
             $rule.disabled | should be "false"
         }
 
-        it "Can create an l3 rule with multiple item based source, destination, applied to and service" {
+        it "Can create an l3 rule with multiple item based source, destination, applied to and service (objects)" {
             $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -Source $testvm1,$testvm2 -destination $testvm1,$testvm2 -action allow -appliedTo $testvm1,$testvm2 -Service $TestService1, $TestService2
             $rule | should not be $null
             $rule = Get-NsxFirewallSection -Name $l3sectionname | Get-NsxFirewallRule -Name "pester_dfw_rule1"
@@ -1374,6 +1374,8 @@ Describe "DFW" {
             $rule.destinations | should beoftype System.Xml.XmlElement
             $rule.appliedToList | should beoftype System.Xml.XmlElement
             @($rule.services.service).count | should be 4
+            $rule.services.service | Where-Object { $_.Name -eq $TestServiceName1 } | should be 1
+            $rule.services.service | Where-Object { $_.Name -eq $TestServiceName2 } | should be 1
             $rule.services.service | Where-Object { $_.protocolName -eq $rawService1 } | should be 1
             $rule.services.service | Where-Object { ( $_.protocolName -eq ($rawservice3 -split "/")[0] ) -and  ( $_.destinationPort -eq ($rawservice3 -split "/")[1] ) } | should be 1
             @($rule.appliedToList.appliedTo).count | should be 2

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -970,6 +970,65 @@ Describe "DFW" {
             $rule.disabled | should be "false"
         }
 
+        it "Can create an l3 rule with raw protocol as the service (No Port Defined)" {
+            $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -action allow -service $TestServiceProto
+            $rule | should not be $null
+            $rule = Get-NsxFirewallSection -Name $l3sectionname | Get-NsxFirewallRule -Name "pester_dfw_rule1"
+            $rule | should not be $null
+            @($rule).count | should be 1
+            $rule.sources | should be $null
+            $rule.destinations | should be $null
+            @($rule.services.service).count | should be 1
+            $rule.services.service.protocolName | should be $TestServiceProto
+            @($rule.appliedToList.appliedto).count | should be 1
+            $rule.appliedToList.appliedTo.Name | should be "DISTRIBUTED_FIREWALL"
+            $rule.appliedToList.appliedTo.Value | should be "DISTRIBUTED_FIREWALL"
+            $rule.appliedToList.appliedTo.Type | should be "DISTRIBUTED_FIREWALL"
+            $rule.name | should be "pester_dfw_rule1"
+            $rule.action | should be allow
+            $rule.disabled | should be "false"
+        }
+
+        it "Can create an l3 rule with raw protocol and port as the service" {
+            $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -action allow -service "$TestServiceProto/$testPort"
+            $rule | should not be $null
+            $rule = Get-NsxFirewallSection -Name $l3sectionname | Get-NsxFirewallRule -Name "pester_dfw_rule1"
+            $rule | should not be $null
+            @($rule).count | should be 1
+            $rule.sources | should be $null
+            $rule.destinations | should be $null
+            @($rule.services.service).count | should be 1
+            $rule.services.service.protocolName | should be $TestServiceProto
+            $rule.services.service.destinationPort | should be $testPort
+            @($rule.appliedToList.appliedto).count | should be 1
+            $rule.appliedToList.appliedTo.Name | should be "DISTRIBUTED_FIREWALL"
+            $rule.appliedToList.appliedTo.Value | should be "DISTRIBUTED_FIREWALL"
+            $rule.appliedToList.appliedTo.Type | should be "DISTRIBUTED_FIREWALL"
+            $rule.name | should be "pester_dfw_rule1"
+            $rule.action | should be allow
+            $rule.disabled | should be "false"
+        }
+
+        it "Can create an l3 rule with raw protocol and port-range as the service" {
+            $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -action allow -service "$TestServiceProto/$testPortRange"
+            $rule | should not be $null
+            $rule = Get-NsxFirewallSection -Name $l3sectionname | Get-NsxFirewallRule -Name "pester_dfw_rule1"
+            $rule | should not be $null
+            @($rule).count | should be 1
+            $rule.sources | should be $null
+            $rule.destinations | should be $null
+            @($rule.services.service).count | should be 1
+            $rule.services.service.protocolName | should be $TestServiceProto
+            $rule.services.service.destinationPort | should be $testPortRange
+            @($rule.appliedToList.appliedto).count | should be 1
+            $rule.appliedToList.appliedTo.Name | should be "DISTRIBUTED_FIREWALL"
+            $rule.appliedToList.appliedTo.Value | should be "DISTRIBUTED_FIREWALL"
+            $rule.appliedToList.appliedTo.Type | should be "DISTRIBUTED_FIREWALL"
+            $rule.name | should be "pester_dfw_rule1"
+            $rule.action | should be allow
+            $rule.disabled | should be "false"
+        }
+
         it "Can create an l3 rule with single source, destination, applied to and service" {
             $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -Source $testvm1 -destination $testvm2 -action allow -appliedTo $testvm1 -service $testService1
             $rule | should not be $null

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -258,9 +258,8 @@ Describe "IPSets" {
             $ipaddress = "1.2.3.4"
             $iprange = "1.2.3.4-2.3.4.5"
             $cidr = "1.2.3.0/24"
-            $hostCidr = "1.2.3.4/32"
             get-nsxipset $ipsetName | remove-nsxipset -Confirm:$false
-            $script:remove = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses "$ipaddress,$iprange,$cidr,$hostCidr"
+            $script:remove = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses "$ipaddress,$iprange,$cidr"
 
         }
 
@@ -275,7 +274,6 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $ipaddress | should be $false
             $ipset.value -split "," -contains $iprange | should be $true
             $ipset.value -split "," -contains $cidr | should be $true
-            $ipset.value -split "," -contains $hostCidr | should be $false
         }
 
         it "Can remove a range from an ip set" {
@@ -283,7 +281,6 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $iprange | should be $false
             $ipset.value -split "," -contains $ipaddress | should be $true
             $ipset.value -split "," -contains $cidr | should be $true
-            $ipset.value -split "," -contains $hostCidr | should be $true
         }
 
         it "Can remove a cidr from an ip set" {
@@ -291,7 +288,6 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $cidr | should be $false
             $ipset.value -split "," -contains $ipaddress | should be $true
             $ipset.value -split "," -contains $iprange | should be $true
-            $ipset.value -split "," -contains $hostCidr | should be $true
         }
 
         it "Can remove multiple values from an ip set" {
@@ -300,23 +296,6 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $ipaddress | should be $false
             $ipset.value -split "," -contains $iprange | should be $false
             $ipset.value -split "," -contains $cidr | should be $true
-            $ipset.value -split "," -contains $hostCidr | should be $false
-        }
-
-        it "Can remove a host cidr when a matching non cidr address is specified" {
-            $ipset = $remove | Remove-NsxIpSetMember -IpAddress $ipaddress
-            $ipset.value -split "," -contains $ipaddress | should be $false
-            $ipset.value -split "," -contains $hostCidr | should be $false
-            $ipset.value -split "," -contains $cidr | should be $true
-            $ipset.value -split "," -contains $iprange | should be $true
-        }
-
-        it "Can remove a non cidr host address when a matching host cidr address is specified" {
-            $ipset = $remove | Remove-NsxIpSetMember -IpAddress $hostCidr
-            $ipset.value -split "," -contains $ipaddress | should be $false
-            $ipset.value -split "," -contains $hostCidr | should be $false
-            $ipset.value -split "," -contains $cidr | should be $true
-            $ipset.value -split "," -contains $iprange | should be $true
         }
 
     }

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -298,5 +298,6 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $cidr | should be $true
         }
 
+
     }
 }

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -258,8 +258,9 @@ Describe "IPSets" {
             $ipaddress = "1.2.3.4"
             $iprange = "1.2.3.4-2.3.4.5"
             $cidr = "1.2.3.0/24"
+            $hostCidr = "1.2.3.4/32"
             get-nsxipset $ipsetName | remove-nsxipset -Confirm:$false
-            $script:remove = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses "$ipaddress,$iprange,$cidr"
+            $script:remove = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses "$ipaddress,$iprange,$cidr,$hostCidr"
 
         }
 
@@ -274,6 +275,7 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $ipaddress | should be $false
             $ipset.value -split "," -contains $iprange | should be $true
             $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $false
         }
 
         it "Can remove a range from an ip set" {
@@ -281,6 +283,7 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $iprange | should be $false
             $ipset.value -split "," -contains $ipaddress | should be $true
             $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $true
         }
 
         it "Can remove a cidr from an ip set" {
@@ -288,6 +291,7 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $cidr | should be $false
             $ipset.value -split "," -contains $ipaddress | should be $true
             $ipset.value -split "," -contains $iprange | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $true
         }
 
         it "Can remove multiple values from an ip set" {
@@ -296,8 +300,24 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $ipaddress | should be $false
             $ipset.value -split "," -contains $iprange | should be $false
             $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $false
         }
 
+        it "Can remove a host cidr when a matching non cidr address is specified" {
+            $ipset = $remove | Remove-NsxIpSetMember -IpAddress $ipaddress
+            $ipset.value -split "," -contains $ipaddress | should be $false
+            $ipset.value -split "," -contains $hostCidr | should be $false
+            $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $iprange | should be $true
+        }
+
+        it "Can remove a non cidr host address when a matching host cidr address is specified" {
+            $ipset = $remove | Remove-NsxIpSetMember -IpAddress $hostCidr
+            $ipset.value -split "," -contains $ipaddress | should be $false
+            $ipset.value -split "," -contains $hostCidr | should be $false
+            $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $iprange | should be $true
+        }
 
     }
 }


### PR DESCRIPTION
Changes to allow protocol/ports to be specified directly in new-nsxfirewallrule rather than supplying a pre-configured service/servicegroup

Changes also allow a combination of manually specified protocol/ports along with supplying a service/servicegroup object