### PR TITLE
Remove-NsxIpSetMember enhancements

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21398,7 +21398,7 @@ function Remove-NsxIpSetMember  {
         # try to remove the last IP Address from an IP Set resulting in a blank
         # value. But it will allow you to create one with no value set... go figure.
         if ( $ValCollection.count -eq 0 ) {
-            throw "Operation will result in an empty IP Set and the API will throw a wobbly"
+            throw "Operation will result in an empty IP Set and the API will throw a 400 error."
         }
 
         if ( $modified ) {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21352,7 +21352,6 @@ function Remove-NsxIpSetMember  {
                         write-warning "$Value not a member of IPSet $($ipset.name)"
                     }
                     else {
-                        write-host "valcollection contains $value"
                         $modified = $true
                         $ValCollection.Remove($value)
                         $ValCollection.Remove("$($value)/32")
@@ -21363,7 +21362,6 @@ function Remove-NsxIpSetMember  {
                         write-warning "$Value not a member of IPSet $($ipset.name)"
                     }
                     else {
-                        write-host "valcollection contains $value"
                         $modified = $true
                         $ValCollection.Remove($value)
                         $ValCollection.Remove("$(($value -split "/")[0])")
@@ -21372,24 +21370,11 @@ function Remove-NsxIpSetMember  {
             }
             else {
                 if ( ( -not ( $valcollection -contains $value ) ) ) {
-            # 1.1.1.1 we need to look for both 1.1.1.1 AND 1.1.1.1/32 to remove..
-            if ($value -match "/|-") {
-                if ( -not ( $valcollection -contains $value )) {
                     write-warning "$Value not a member of IPSet $($ipset.name)"
                 }
                 else {
                     $modified = $true
                     $ValCollection.Remove($value)
-                }
-            }
-            else {
-                if ( ( -not ( $valcollection -contains $value ) ) -and ( -not ( $valcollection -contains "$($value)/32" ) ) ) {
-                    write-warning "$Value not a member of IPSet $($ipset.name)"
-                }
-                else {
-                    $modified = $true
-                    $ValCollection.Remove($value)
-                    $ValCollection.Remove("$($value)/32")
                 }
             }
         }
@@ -21416,7 +21401,6 @@ function Remove-NsxIpSetMember  {
             }
         }
     }
-    end {}
 }
 
 function Remove-NsxIpPool {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21271,6 +21271,33 @@ function Remove-NsxIpSetMember  {
     IP Range: (eg, 1.2.3.4-1.2.3.10)
     IP Subnet: (eg, 1.2.3.0/24)
 
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 3.3.3.3
+
+    Removes the address 3.3.3.3 and 3.3.3.3/32 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 3.3.3.3/32
+
+    Removes the address 3.3.3.3 and 3.3.3.3/32 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember -IPAddress 10.0.0.0/8
+
+    Removes the network 10.0.0.0/8 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember
+    -IPAddress 192.168.1.1-192.168.1.254
+
+    Removes the range 192.168.1.1-192.168.1.254 from the given NSX IPSet
+
+    .EXAMPLE
+    PS C:\> Get-NsxIpset Test-IPSet | Remove-NsxIpSetMember
+    -IPAddress 3.3.3.3,10.0.0.0/8,192.168.1.1-192.168.1.254
+
+    Removes the given IP Addresses, Networks and Ranges from the NSX IPSet
+
     #>
 
     [CmdletBinding()]
@@ -21305,12 +21332,27 @@ function Remove-NsxIpSetMember  {
         [system.collections.arraylist]$ValCollection = $_ipset.value -split ","
         $modified = $false
         foreach ( $value in $IPAddress ) {
-            if ( -not ( $valcollection -contains $value )) {
-                write-warning "$Value $value not a member of IPSet $($ipset.name)"
+            # An IPSET allows the users to enter a host as either 1.1.1.1 or
+            # 1.1.1.1/32. So if the users specifies that they want to remove
+            # 1.1.1.1 we need to look for both 1.1.1.1 AND 1.1.1.1/32 to remove..
+            if ($value -match "/|-") {
+                if ( -not ( $valcollection -contains $value )) {
+                    write-warning "$Value not a member of IPSet $($ipset.name)"
+                }
+                else {
+                    $modified = $true
+                    $ValCollection.Remove($value)
+                }
             }
             else {
-                $modified = $true
-                $ValCollection.Remove($value)
+                if ( ( -not ( $valcollection -contains $value ) ) -and ( -not ( $valcollection -contains "$($value)/32" ) ) ) {
+                    write-warning "$Value not a member of IPSet $($ipset.name)"
+                }
+                else {
+                    $modified = $true
+                    $ValCollection.Remove($value)
+                    $ValCollection.Remove("$($value)/32")
+                }
             }
         }
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -21345,7 +21345,6 @@ function Remove-NsxIpSetMember  {
         foreach ( $value in $IPAddress ) {
             # An IPSET allows the users to enter a host as either 1.1.1.1 or
             # 1.1.1.1/32. So if the users specifies that they want to remove
-<<<<<<< HEAD
             # 1.1.1.1 we need to look for both 1.1.1.1 AND 1.1.1.1/32 to remove.
             if ( Validate-IPHost $value ) {
                 if ( $value -as [ipaddress] ) {
@@ -21373,7 +21372,6 @@ function Remove-NsxIpSetMember  {
             }
             else {
                 if ( ( -not ( $valcollection -contains $value ) ) ) {
-=======
             # 1.1.1.1 we need to look for both 1.1.1.1 AND 1.1.1.1/32 to remove..
             if ($value -match "/|-") {
                 if ( -not ( $valcollection -contains $value )) {
@@ -21386,16 +21384,12 @@ function Remove-NsxIpSetMember  {
             }
             else {
                 if ( ( -not ( $valcollection -contains $value ) ) -and ( -not ( $valcollection -contains "$($value)/32" ) ) ) {
->>>>>>> 89fe6086e995491b669924b93164ba7fe09ac349
                     write-warning "$Value not a member of IPSet $($ipset.name)"
                 }
                 else {
                     $modified = $true
                     $ValCollection.Remove($value)
-<<<<<<< HEAD
-=======
                     $ValCollection.Remove("$($value)/32")
->>>>>>> 89fe6086e995491b669924b93164ba7fe09ac349
                 }
             }
         }

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -258,8 +258,9 @@ Describe "IPSets" {
             $ipaddress = "1.2.3.4"
             $iprange = "1.2.3.4-2.3.4.5"
             $cidr = "1.2.3.0/24"
+            $hostCidr = "1.2.3.4/32"
             get-nsxipset $ipsetName | remove-nsxipset -Confirm:$false
-            $script:remove = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses "$ipaddress,$iprange,$cidr"
+            $script:remove = New-nsxipset -Name $ipsetName -Description $ipsetDesc -IPAddresses "$ipaddress,$iprange,$cidr,$hostCidr"
 
         }
 
@@ -274,6 +275,7 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $ipaddress | should be $false
             $ipset.value -split "," -contains $iprange | should be $true
             $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $false
         }
 
         it "Can remove a range from an ip set" {
@@ -281,6 +283,7 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $iprange | should be $false
             $ipset.value -split "," -contains $ipaddress | should be $true
             $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $true
         }
 
         it "Can remove a cidr from an ip set" {
@@ -288,6 +291,7 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $cidr | should be $false
             $ipset.value -split "," -contains $ipaddress | should be $true
             $ipset.value -split "," -contains $iprange | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $true
         }
 
         it "Can remove multiple values from an ip set" {
@@ -296,8 +300,24 @@ Describe "IPSets" {
             $ipset.value -split "," -contains $ipaddress | should be $false
             $ipset.value -split "," -contains $iprange | should be $false
             $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $hostCidr | should be $false
         }
 
+        it "Can remove a host cidr when a matching non cidr address is specified" {
+            $ipset = $remove | Remove-NsxIpSetMember -IpAddress $ipaddress
+            $ipset.value -split "," -contains $ipaddress | should be $false
+            $ipset.value -split "," -contains $hostCidr | should be $false
+            $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $iprange | should be $true
+        }
+
+        it "Can remove a non cidr host address when a matching host cidr address is specified" {
+            $ipset = $remove | Remove-NsxIpSetMember -IpAddress $hostCidr
+            $ipset.value -split "," -contains $ipaddress | should be $false
+            $ipset.value -split "," -contains $hostCidr | should be $false
+            $ipset.value -split "," -contains $cidr | should be $true
+            $ipset.value -split "," -contains $iprange | should be $true
+        }
 
     }
 }


### PR DESCRIPTION
- Removed duplicate display text when a given value is not a member of the IP Set
- Improved logic to remove both host IP Address and a /32 address when a single IP address or /32 is specified.
- Added feature to detect if removing the entries will result in an empty IP Set and throw an appropriate error, rather than relying on the API to return a 400 response which is undecipherable in PowerNSX.
- Updated tests