### PR TITLE
Logical Router tenant property

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -9214,6 +9214,9 @@ function New-NsxLogicalRouter {
         [Parameter (Mandatory=$true)]
             [ValidateNotNullOrEmpty()]
             [string]$Name,
+        [Parameter (Mandatory=$false)]
+            [ValidateNotNullOrEmpty()]
+            [String]$Tenant,
         [Parameter (Mandatory=$true)]
             [ValidateScript({ Validate-LogicalSwitchOrDistributedPortGroup $_ })]
             [object]$ManagementPortGroup,
@@ -9257,6 +9260,7 @@ function New-NsxLogicalRouter {
 
         Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "name" -xmlElementText $Name
         Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "type" -xmlElementText "distributedRouter"
+        if ( $Tenant ) { Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "tenant" -xmlElementText $Tenant }
 
         switch ($ManagementPortGroup){
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -19379,9 +19379,12 @@ function New-NsxSecurityGroup   {
         [Parameter (Mandatory=$false)]
             [switch]$ReturnObjectIdOnly=$false,
         [Parameter (Mandatory=$False)]
+            [switch]$localMembersOnly=$false,
+        [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
             [PSCustomObject]$Connection=$defaultNSXConnection
+
     )
 
     begin {}
@@ -19410,6 +19413,7 @@ function New-NsxSecurityGroup   {
             }
         }
 
+
         if ( $excludeMember ) {
 
             foreach ( $Member in $ExcludeMember) {
@@ -19424,6 +19428,17 @@ function New-NsxSecurityGroup   {
                     Add-XmlElement -xmlRoot $xmlMember -xmlElementName "objectId" -xmlElementText $member.ExtensionData.MoRef.Value
                 }
             }
+        }
+
+        if (( $localMembersOnly ) -and ( $scopeid -eq "universalroot-0")) {
+            [System.XML.XMLElement]$xmlMember = $XMLDoc.CreateElement("extendedAttributes")
+            $xmlroot.appendChild($xmlMember) | out-null
+            [System.XML.XMLElement]$xmlsubMember = $XMLDoc.CreateElement("extendedAttribute")
+            Add-XmlElement -xmlRoot $xmlSubMember -xmlElementName "name" -xmlElementText "localMembersOnly"
+            Add-XmlElement -xmlRoot $xmlSubMember -xmlElementName "value" -xmlElementText "true"
+            $xmlmember.appendChild($xmlsubMember) | out-null
+
+  
         }
 
         #Do the post
@@ -19863,6 +19878,8 @@ function New-NsxSecurityTag {
             [string]$Name,
         [Parameter (Mandatory=$false)]
             [string]$Description,
+        [Parameter (Mandatory=$false)]
+            [switch]$isUniversal,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -19890,6 +19907,10 @@ function New-NsxSecurityTag {
         #Optional fields
         if ( $PsBoundParameters.ContainsKey('Description')) {
             Add-XmlElement -xmlRoot $xmlRoot -xmlElementName "description" -xmlElementText "$Description"
+        }
+
+        if ( $isUniversal) {
+            Add-xmlElement -xmlroot $xmlRoot -xmlElementName "isUniversal" -xmlElementText "true"
         }
 
         #Do the post


### PR DESCRIPTION
NSX Edges and logical routers have a tenant property, however PNSX only allows for the tenant property to be set for the Edge. 

I've added the tenant XML and parameter to the new-nsxlogicalrouter to be able to set a tenant ID for the LR as well. 

Manually tested but no automated test has been created yet. 