### PR TITLE
Fix test failing under 6.3.x

### DIFF
--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -219,7 +219,7 @@ Describe "DFW" {
         it "Can delete an L2 section with rules in it when forced" {
             $section = Get-NsxFirewallSection -name $l2sectionname -sectionType layer2sections
             $section | should not be $null
-            $section | Get-NsxFirewallRule | should not be $null
+            $section | Get-NsxFirewallRule -RuleType layer2sections | should not be $null
             { $section | Remove-NsxFirewallSection -Confirm:$false -force } | should not Throw
         }
     }


### PR DESCRIPTION
Seems our API previously accepted an invalid delete like the following
DELETE : /api/4.0/firewall/globalroot-0/config/layer3sections/<l2sectionid>
6.3.x no longer accepts this (correctly)

Fixes #158 