### PR TITLE
Controller password handling

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6253,10 +6253,10 @@ function New-NsxController {
     )
 
     begin {
-        $count = get-nsxcontroller -connection $defaultNSXConnection | measure
+        $count = get-nsxcontroller -connection $Connection | measure
 
-        if ( ($PSBoundParameters.ContainsKey("Password")) -and ($count.count -eq 1)) {
-                Throw "A Controller already exists. Secondary and Tertiary controllers do not use the password parameter  $_"
+        if ( ($PSBoundParameters.ContainsKey("Password")) -and ($count.count -gt 1)) {
+                Throw "A Controller already exists. Secondary and Tertiary controllers do not use the password parameter"
             }
         if ( -not ($PSBoundParameters.ContainsKey("Password")) -and ($count.count -eq 0)) {
                 Throw "Password property must be defined for the first controller. Define a password with -Password"

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6199,6 +6199,10 @@ function New-NsxController {
     $ControllerPortGroup = Get-VDPortGroup $ControllerPortGroupName -server $Connection.VIConnection
     New-NsxController -ControllerName $ControllerName -ipPool $ippool -cluster $ControllerCluster -datastore $ControllerDatastore -PortGroup $ControllerPortGroup -password $DefaultNsxControllerPassword -connection $Connection -confirm:$false
 
+    .EXAMPLE
+    A secondary or tertiary controller does not require a Password to be defined. 
+
+    New-NsxController -ipPool $ippool -cluster $ControllerCluster -datastore $ControllerDatastore -PortGroup $ControllerPortGroup -connection $Connection -confirm:$false
     #>
 
 
@@ -6249,7 +6253,6 @@ function New-NsxController {
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
             [PSCustomObject]$Connection=$defaultNSXConnection
-
     )
 
     begin {
@@ -6262,9 +6265,6 @@ function New-NsxController {
                 Throw "Password property must be defined for the first controller. Define a password with -Password"
             }
         }
-
-        #if 1 controller and password defined, throw
-        #if 0 controler and password not defined
 
     process {
 


### PR DESCRIPTION
Removed the requirement for defining a password for secondary/tertiary controllers.

Updated examples.
Can deal with:

Zero controllers - no password, throw. - clear error message stating issue and fix.
1 or more controllers - password defined, throw - clear error message stating issue and fix.

Tested: macOS/Windows 624/631