### PR TITLE
Fixes #261

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -5672,7 +5672,7 @@ function Get-NsxManagerTimeSettings {
 
     )
 
-    $role = Get-NsxUserRole $Connection.Credential.Username
+    $role = Get-NsxUserRole $Connection.Credential.Username -connection $connection
     if ( $role.role -ne 'super_user' ) {
         throw "Appliance Management APIs require a local NSX Manager account (super_user role access) "
     }
@@ -5740,7 +5740,7 @@ function Set-NsxManagerTimeSettings {
 
     )
 
-    $role = Get-NsxUserRole $Connection.Credential.Username
+    $role = Get-NsxUserRole $Connection.Credential.Username -Connection $Connection
     if ( $role.role -ne 'super_user' ) {
         throw "Appliance Management APIs require a local NSX Manager account (super_user role access) "
     }
@@ -5757,7 +5757,7 @@ function Set-NsxManagerTimeSettings {
 
                 write-warning "Existing NTP servers are configured and will be retained.  Use Clear-NsxManagerTimeSettings to remove them."
                 #Api doesnt allow 'updates', so we have to save existing, then remove, then readd the union of old and new.
-                Clear-NsxManagerTimeSettings
+                Clear-NsxManagerTimeSettings -Connection $Connection
 
                 foreach ($Server in $ntpserver) {
                     if ( $Existing.timeSettings.ntpServer.string -notcontains $server ) {
@@ -5779,8 +5779,8 @@ function Set-NsxManagerTimeSettings {
 
         $uri = "/api/1.0/appliance-management/system/timesettings"
         $null = Invoke-NsxRestMethod -Method put -body $Existing.timeSettings.outerXml -uri $uri -Connection $Connection
-        Get-NsxManagerTimeSettings
-    }
+        Get-NsxManagerTimeSettings -Connection $Connection
+        }
     else {
         throw "Unexpected response from API when querying existing time settings."
     }
@@ -24042,7 +24042,7 @@ function Set-NsxFirewallThreshold {
     )
 
     begin {}
-    
+
     process {
 
         #Capture existing thresholds

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -17,7 +17,7 @@ Describe "NSXManager" {
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
         $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
-        $script:adminConnection = Connect-NsxServer -NsxServer $DefaultNsxConnection.Server -Credential $PNSXTestDefMgrCred
+        $script:adminConnection = Connect-NsxServer -NsxServer $DefaultNsxConnection.Server -Credential $PNSXTestDefMgrCred -DefaultConnection:$false
 
 
         #Put any script scope variables you need to reference in your tests.
@@ -60,7 +60,7 @@ Describe "NSXManager" {
         #Connect-NsxServer tests
         it "Can connect directly to NSX server using admin account - legacy mode" {
             $NSXManager = $DefaultNsxConnection.Server
-            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore"
+            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false
             $DirectConn | should not be $null
             $DirectConn.Version | should not be $null
             $DirectConn.BuildNumber | should not be $null
@@ -69,7 +69,7 @@ Describe "NSXManager" {
 
         it "Can connect directly to NSX server using Ent_Admin SSO account" {
             $NSXManager = $DefaultNsxConnection.Server
-            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false
             $DirectConn | should not be $null
             $DirectConn.Version | should be $null
             $DirectConn.BuildNumber | should be $null
@@ -139,14 +139,14 @@ Describe "NSXManager" {
         it "Can clear existing NTP configuration" {
             $TimeConfig = Clear-NsxManagerTimeSettings -connection $adminConnection
             $TimeConfig | should be $null
-            $GetTimeConfig = Get-NsxManagerTimeSettings
+            $GetTimeConfig = Get-NsxManagerTimeSettings -connection $adminConnection
             $GetTimeConfig.NtpServer | should be $null
         }
 
         it "Can configure NTP servers" {
             $TimeConfig = Set-NsxManagerTimeSettings -NtpServer $NTPServer1, $NTPServer2 -connection $adminConnection
             $TimeConfig.ntpserver | should not be $null
-            $GetTimeConfig = Get-NsxManagerTimeSettings
+            $GetTimeConfig = Get-NsxManagerTimeSettings -connection $adminConnection
             $GetTimeConfig.ntpserver.string -contains $NTPServer1 | should be $true
             $GetTimeConfig.ntpserver.string -contains $NTPServer2 | should be $true
         }
@@ -154,7 +154,7 @@ Describe "NSXManager" {
         it "Can configure timezone configuration" {
             $TimeConfig = Set-NsxManagerTimeSettings -TimeZone $TimeZone -connection $adminConnection
             $TimeConfig.timezone | should be $Timezone
-            $GetTimeConfig = Get-NsxManagerTimeSettings
+            $GetTimeConfig = Get-NsxManagerTimeSettings -connection $adminConnection
             $TimeConfig.timezone | should be $Timezone
         }
     }


### PR DESCRIPTION
- Added -DefaultConnection:$false on admin connection causing unintended override of $defaultnsxconnection.
- resolved connection param being ignored by clear, get and set-nsxmanagertimesettings.