### PR TITLE
SSL VPN Tests

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -13163,7 +13163,7 @@ function Set-NsxSslVpn {
         [Parameter (Mandatory=$False)]
             [string]$ClientNotification,
         [Parameter (Mandatory=$False)]
-            [string]$EnablePublicUrlAccess,
+            [string]$EnablePublicUrlAccess=$False,
         [Parameter (Mandatory=$False)]
             [int]$ForcedTimeout,
         [Parameter (Mandatory=$False)]

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -13163,7 +13163,7 @@ function Set-NsxSslVpn {
         [Parameter (Mandatory=$False)]
             [string]$ClientNotification,
         [Parameter (Mandatory=$False)]
-            [switch]$EnablePublicUrlAccess,
+            [string]$EnablePublicUrlAccess=$False,
         [Parameter (Mandatory=$False)]
             [int]$ForcedTimeout,
         [Parameter (Mandatory=$False)]
@@ -13197,7 +13197,10 @@ function Set-NsxSslVpn {
     )
 
     begin {
-
+        if (($EnablePublicUrlAccess -eq $True) -and ([version]$Connection.version -ge [version]"6.3.0")){
+            Write-Warning "PublicURL feature has been deprecated in the 6.3.X release. It has not been enabled."
+            $EnablePublicUrlAccess = $False
+        }
     }
 
     process {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -13163,7 +13163,7 @@ function Set-NsxSslVpn {
         [Parameter (Mandatory=$False)]
             [string]$ClientNotification,
         [Parameter (Mandatory=$False)]
-            [string]$EnablePublicUrlAccess=$False,
+            [string]$EnablePublicUrlAccess,
         [Parameter (Mandatory=$False)]
             [int]$ForcedTimeout,
         [Parameter (Mandatory=$False)]

--- a/tests/integration/07.SslVpn.Tests.ps1
+++ b/tests/integration/07.SslVpn.Tests.ps1
@@ -78,7 +78,7 @@ Describe "sslvpn" {
 
             get-nsxedge $ssledgename | Get-NsxSslVpn | Set-NsxSslVpn -EnableCompression `
                 -ForceVirtualKeyboard -RandomizeVirtualkeys -preventMultipleLogon `
-                -ClientNotification $notificationstring -EnablePublicUrlAccess `
+                -ClientNotification $notificationstring -EnablePublicUrlAccess $True `
                 -ForcedTimeout $forcedTimeout -SessionIdleTimeout $sessionIdleTimeout -ClientAutoReconnect -ClientUpgradeNotification `
                 -EnableLogging -LogLevel $loglevel -Enable_AES128_SHA -ServerAddress $sslEdgeIp1 -ServerPort $serverport -Confirm:$false
             $sslvpn = get-nsxedge $ssledgename | Get-NsxSslVpn

--- a/tests/integration/07.SslVpn.Tests.ps1
+++ b/tests/integration/07.SslVpn.Tests.ps1
@@ -78,7 +78,7 @@ Describe "sslvpn" {
 
             get-nsxedge $ssledgename | Get-NsxSslVpn | Set-NsxSslVpn -EnableCompression `
                 -ForceVirtualKeyboard -RandomizeVirtualkeys -preventMultipleLogon `
-                -ClientNotification $notificationstring -EnablePublicUrlAccess `
+                -ClientNotification $notificationstring  `
                 -ForcedTimeout $forcedTimeout -SessionIdleTimeout $sessionIdleTimeout -ClientAutoReconnect -ClientUpgradeNotification `
                 -EnableLogging -LogLevel $loglevel -Enable_AES128_SHA -ServerAddress $sslEdgeIp1 -ServerPort $serverport -Confirm:$false
             $sslvpn = get-nsxedge $ssledgename | Get-NsxSslVpn

--- a/tests/integration/07.SslVpn.Tests.ps1
+++ b/tests/integration/07.SslVpn.Tests.ps1
@@ -78,7 +78,7 @@ Describe "sslvpn" {
 
             get-nsxedge $ssledgename | Get-NsxSslVpn | Set-NsxSslVpn -EnableCompression `
                 -ForceVirtualKeyboard -RandomizeVirtualkeys -preventMultipleLogon `
-                -ClientNotification $notificationstring  `
+                -ClientNotification $notificationstring -EnablePublicUrlAccess `
                 -ForcedTimeout $forcedTimeout -SessionIdleTimeout $sessionIdleTimeout -ClientAutoReconnect -ClientUpgradeNotification `
                 -EnableLogging -LogLevel $loglevel -Enable_AES128_SHA -ServerAddress $sslEdgeIp1 -ServerPort $serverport -Confirm:$false
             $sslvpn = get-nsxedge $ssledgename | Get-NsxSslVpn

--- a/tests/integration/07.SslVpn.Tests.ps1
+++ b/tests/integration/07.SslVpn.Tests.ps1
@@ -89,7 +89,6 @@ Describe "sslvpn" {
             $sslvpn.advancedConfig.randomizeVirtualkeys | should be "true"
             $sslvpn.advancedConfig.preventMultipleLogon | should be "true"
             $sslvpn.advancedConfig.ClientNotification | should be $notificationstring
-            $sslvpn.advancedConfig.enablePublicUrlAccess | should be "true"
             $sslvpn.advancedConfig.timeout.forcedTimeout | should be $forcedTimeout
             $sslvpn.advancedConfig.timeout.sessionIdleTimeout | should be $sessionIdleTimeout
             $sslvpn.clientConfiguration.autoReconnect | should be "true"


### PR DESCRIPTION
Closes #157 
Fixes 6.3 deprecation of PublicWeb
Changes tests per chat with Nick.

Tested on 6.2.4,6.2.6, 6.3.0 macOS/Windows.