### PR TITLE
fix new-nsxcontroller to work on powercore

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6411,12 +6411,12 @@ function New-NsxController {
             catch {
                 throw "Controller deployment failed. $_"
             }
-            if ( -not (($response -match "jobdata-\d+") -and ($response.Headers.keys -contains "location") -and ($response.Headers["location"] -match "/api/2.0/vdn/controller/" )) ) {
+            if ( -not (($response.content -match "jobdata-\d+") -and ($response.Headers.keys -contains "Location") -and ($response.Headers["Location"] -match "/api/2.0/vdn/controller/" )) ) {
                 throw "Controller deployment failed. $($response.content)"
             }
 
             #Get the new controller id so we can get its status later...
-            $controllerid = $response.Headers["location"] -replace "/api/2.0/vdn/controller/"
+            $controllerid = $response.Headers["Location"] -replace "/api/2.0/vdn/controller/"
 
             #The post is ansync - the controller deployment can fail after the api accepts the post.  we need to check on the status of the job.
             $jobid = $response.content


### PR DESCRIPTION
Fix for New-NsxController throws error on PowerShellcore #203.
I made parsing response strict in New-NsxController.

In powernsx on mac, request is sent, handled correctly by NSXmanger and response is sent back.
However the following conditions get 'False'.
 - $response -match "jobdata-\d+"
 - $response.Headers["location"] -match "/api/2.0/vdn/controller/"
I'm not sure whether this issue comes from powershell on mac, but this is fixed by strictly checking the response variable.
This change is also confirmed on Windows.