### PR TITLE
fix new-nsxcontroller to work on powercore

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -195,8 +195,12 @@ https://github.com/vmware/powernsx/issues
             public Dictionary<string, string> Headers;
             public string Content;
             public internalWebResponse() {
-                this.Headers = new Dictionary<string,string>();
+                this.Headers = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
             }
+	    public override string ToString()
+	    {
+		return this.Content;
+	    }
         }
 
         public class InternalWebRequestException: Exception


### PR DESCRIPTION
Fix for New-NsxController throws error on PowerShellcore #203.
I made parsing response strict in New-NsxController.

In powernsx on mac, request is sent, handled correctly by NSXmanger and response is sent back.
However the following conditions get 'False'.

$response -match "jobdata-\d+"
$response.Headers["location"] -match "/api/2.0/vdn/controller/"
I'm not sure whether this issue comes from powershell on mac, but this is fixed by strictly checking the response variable.
This change is also confirmed on Windows.