### PR TITLE
Added cmdlet Get-NsxUniversalSyncStatus

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -339,7 +339,8 @@ FunctionsToExport = @(
     'Get-NsxFirewallRuleMember',
     'Add-NsxFirewallRuleMember',
     'Remove-NsxFirewallRuleMember',
-    'Remove-NsxController'
+    'Remove-NsxController',
+    'Get-NsxUniversalSyncStatus'
 )
 
 # Cmdlets to export from this module


### PR DESCRIPTION
- Added a cmdlet to check the overall universal sync status of the connected NSX Manager.
- Provides the ability to query the individual sync status of universal objects if specified.

Pester tests run on Windows against 6.2.5/6.3.1.
Manual tests run on Core(MACOS) against 6.2.5/6.3.1

Addresses issue raised in #31 