### PR TITLE
Validate-LoadBalancerPoolMember: Remove ipaddress check if pool membe…

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -2740,9 +2740,10 @@ Function Validate-LoadBalancerPoolMember {
         if ( -not ( $argument | get-member -name edgeId -Membertype Properties)) {
             throw "XML Element specified does not contain an edgeId property."
         }
-        if ( -not ( $argument | get-member -name ipAddress -Membertype Properties)) {
-            throw "XML Element specified does not contain an ipAddress property."
-        }
+        #Disable check because it can be also a groupingObjectId...
+        #if ( -not ( $argument | get-member -name ipAddress -Membertype Properties)) {
+        #    throw "XML Element specified does not contain an ipAddress property."
+        #}
         if ( -not ( $argument | get-member -name name -Membertype Properties)) {
             throw "XML Element specified does not contain a name property."
         }


### PR DESCRIPTION
…r use GroupingObjectId

$pool = get-NsxEdge myedge | Get-NsxLoadBalancer | get-NsxLoadBalancerPool -name mypool

PS C:\Users\alagoutte\Documents> $pool.member

memberId           : member-27
groupingObjectId   : vm-227
groupingObjectName : ALG-WEB-INLINE-1
weight             : 1
monitorPort        : 80
port               : 80
maxConn            : 0
minConn            : 0
condition          : enabled
name               : ALG-wEB-INLINE-1

PS C:\Users\alagoutte\Documents>  $pool | Get-NsxLoadBalancerPoolMember ALG-WEB-INLINE-1 | remove-nsxLoadbalancerPoolMember
Remove-NsxLoadBalancerPoolMember : Impossible de valider l'argument sur le paramètre «LoadBalancerPoolMember». XML Element specified does not contain an ipAddress property.
Au caractère Ligne:1 : 58
+ ... alancerPoolMember ALG-WEB-INLINE-1 | remove-nsxLoadbalancerPoolMember
+                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidData : (System.Xml.XmlElement:XmlElement) [Remove-NsxLoadBalancerPoolMember], ParameterBindingValidationException
+ FullyQualifiedErrorId : ParameterArgumentValidationError,Remove-NsxLoadBalancerPoolMember

Contribute to fix #24