### PR TITLE
Add Transport Zone and Cross VC Role manipulation cmdlets

### DIFF
--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -310,6 +310,7 @@ FunctionsToExport = @(
     'Get-NsxManagerSystemSummary',
     'Get-NsxManagerCertificate',
     'Get-NsxManagerRole',
+    'Set-NsxManagerRole',
     'New-NsxServiceGroup',
     'Add-NsxServiceGroupMember',
     'Get-NsxServiceGroup',

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -312,6 +312,8 @@ FunctionsToExport = @(
     'Get-NsxManagerRole',
     'Set-NsxManagerRole',
     'Add-NsxSecondaryManager',
+    'Get-NsxSecondaryManager',
+    'Remove-NsxSecondaryManager',
     'New-NsxServiceGroup',
     'Add-NsxServiceGroupMember',
     'Get-NsxServiceGroup',

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -311,6 +311,7 @@ FunctionsToExport = @(
     'Get-NsxManagerCertificate',
     'Get-NsxManagerRole',
     'Set-NsxManagerRole',
+    'Add-NsxSecondaryManager',
     'New-NsxServiceGroup',
     'Add-NsxServiceGroupMember',
     'Get-NsxServiceGroup',

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -112,6 +112,7 @@ FunctionsToExport = @(
     'Set-NsxManager',
     'New-NsxController',
     'Get-NsxController',
+    'Remove-NsxController',
     'Wait-NsxControllerJob',
     'New-NsxIpPool',
     'Get-NsxIpPool',

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -104,6 +104,7 @@ FunctionsToExport = @(
     'Get-PowerNsxVersion',
     'Get-NsxClusterStatus',
     'Invoke-NsxCli',
+    'Wait-NsxJob',
     'Get-NsxCliDfwFilter',
     'Get-NsxCliDfwRule',
     'Get-NsxCliDfwAddrSet',
@@ -111,6 +112,7 @@ FunctionsToExport = @(
     'Set-NsxManager',
     'New-NsxController',
     'Get-NsxController',
+    'Wait-NsxControllerJob',
     'New-NsxIpPool',
     'Get-NsxIpPool',
     'Remove-NsxIpPool'

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -127,6 +127,8 @@ FunctionsToExport = @(
     'Get-NsxTransportZone',
     'New-NsxTransportZone',
     'Remove-NsxTransportZone',
+    'Add-NsxTransportZoneMember',
+    'Remove-NsxTransportZoneMember',
     'Get-NsxLogicalSwitch',
     'New-NsxLogicalSwitch',
     'Remove-NsxLogicalSwitch',

--- a/PowerNSX.psd1
+++ b/PowerNSX.psd1
@@ -311,6 +311,8 @@ FunctionsToExport = @(
     'Get-NsxManagerCertificate',
     'Get-NsxManagerRole',
     'Set-NsxManagerRole',
+    'Invoke-NsxManagerSync',
+    'Get-NsxManagerSyncStatus',
     'Add-NsxSecondaryManager',
     'Get-NsxSecondaryManager',
     'Remove-NsxSecondaryManager',

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6477,7 +6477,7 @@ function Add-NsxSecondaryManager {
     Standalone role.
 
     #>
-
+    [CmdletBinding(DefaultParameterSetName="Credential")]
     param (
 
         [Parameter (Mandatory=$True)]
@@ -6517,7 +6517,7 @@ function Add-NsxSecondaryManager {
     }
 
     #Build cred object for default auth if user specified username/pass
-    if ($PSCmdlet.ParameterSetName = "UserPass" ) {
+    if ($PSCmdlet.ParameterSetName -eq "UserPass" ) {
         $Credential = new-object System.Management.Automation.PSCredential($Username, $(ConvertTo-SecureString $Password -AsPlainText -Force))
     }
     else {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6669,8 +6669,10 @@ function Remove-NsxSecondaryManager {
             [System.Xml.XmlElement]$SecondaryManager,
         [Parameter (Mandatory=$False)]
             #Confirm removal.
-            [ValidateNotNullorEmpty()]
             [switch]$Confirm=$True,
+        [Parameter (Mandatory=$False)]
+            #Force removal of a missing secondary.
+            [switch]$Force,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -6690,7 +6692,12 @@ function Remove-NsxSecondaryManager {
     }
     else { $decision = 0 }
     if ($decision -eq 0) {
-        $URI = "/api/2.0/universalsync/configuration/nsxmanagers/$($SecondaryManager.uuid)"
+        if ( $PSBoundParameters.ContainsKey("Force") {
+            $URI = "/api/2.0/universalsync/configuration/nsxmanagers/$($SecondaryManager.uuid)?force=true"
+        }
+        else{
+            $URI = "/api/2.0/universalsync/configuration/nsxmanagers/$($SecondaryManager.uuid)"
+        }
 
         try  {
             $response = invoke-nsxwebrequest -method "delete" -uri $URI -connection $connection

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6559,8 +6559,8 @@ function Get-NsxManagerSyncStatus {
 
     [System.Xml.XmlDocument]$result = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
 
-    if (Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $result -Query 'child::universalSyncRole') {
-        $result.universalSyncRole
+    if (Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $result -Query 'child::replicationStatus') {
+        $result.replicationStatus
     }
 
 }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6431,8 +6431,8 @@ function Wait-NsxControllerJob {
             #Job Id string as returned from the api
             [string]$JobId,
         [Parameter (Mandatory=$false)]
-            #Seconds to wait before declaring a timeout.  Timeout defaults to 720 seconds, which is longer than the NSX internal timeout and rollback of a failed controller deployment.
-            [int]$WaitTimeout=720,
+            #Seconds to wait before declaring a timeout.  Timeout defaults to 800 seconds, which is longer than the NSX internal timeout and rollback of a failed controller deployment of around 720 seconds.
+            [int]$WaitTimeout=800,
         [Parameter (Mandatory=$false)]
             #Do we prompt user an allow them to reset the timeout timer, or throw on timeout
             [switch]$FailOnTimeout=$false,
@@ -6571,8 +6571,8 @@ function New-NsxController {
             #NOTE: Not waiting means we do NOT return a controller object!
             [switch]$Wait=$false,
         [Parameter ( Mandatory=$False)]
-            #Timeout waiting for controller to become 'RUNNING' before user is prompted to continue or cancel. Defaults to 720 seconds to exceed the normal NSX rollback timeout of 600 seconds.
-            [int]$WaitTimeout = 720,
+            #Timeout waiting for controller to become 'RUNNING' before user is prompted to continue or cancel. Defaults to 800 seconds to exceed the normal NSX rollback timeout of 720 seconds.
+            [int]$WaitTimeout = 800,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6501,6 +6501,70 @@ function Set-NsxManagerRole {
     Get-NsxManagerRole -Connection $Connection
 }
 
+function Invoke-NsxManagerSync {
+    <#
+    .SYNOPSIS
+    Triggers synchronisation of universal objects from a primary NSX Manager.
+
+    .DESCRIPTION
+    The NSX Manager is the central management component of VMware NSX for
+    vSphere.
+
+    The Invoke-NsxManagerSync cmdlet triggers the universal sync service to
+    replicate universally scoped objects to secondary NSX Managers.
+
+    #>
+
+    param (
+
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+    )
+
+    $URI = "/api/2.0/universalsync/sync?action=invoke"
+
+    try  {
+        $response = invoke-nsxwebrequest -method "post" -uri $URI -connection $connection
+    }
+    catch {
+        Throw "Failed to invoke synchronisation. $_"
+    }
+}
+
+function Get-NsxManagerSyncStatus {
+    <#
+    .SYNOPSIS
+    Retrieves NSX Manager universal sync status.
+
+    .DESCRIPTION
+    The NSX Manager is the central management component of VMware NSX for
+    vSphere.
+
+    The Get-NsxManagerSyncStatus cmdlet retrieves the current status of the
+    universal sync service on the NSX Manager against which the command is run.
+    #>
+
+    param (
+
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+
+    )
+
+    $URI = "/api/2.0/universalsync/status"
+
+    [System.Xml.XmlDocument]$result = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+
+    if (Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $result -Query 'child::universalSyncRole') {
+        $result.universalSyncRole
+    }
+
+}
+
 function Add-NsxSecondaryManager {
     <#
     .SYNOPSIS

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6563,7 +6563,7 @@ function Add-NsxSecondaryManager {
     try  {
         $response = invoke-nsxwebrequest -method "post" -body $NsxManagerInfoElement.OuterXml -uri $URI -connection $connection
         $content = [xml]$response.content
-        $content
+        $content.nsxManagerInfo
     }
     Catch {
         Throw "Failed adding secondary NSX Manager.  $_"

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6484,7 +6484,7 @@ function Set-NsxManagerRole {
         if ( $_ -match '.*(\<\?xml version="1\.0" encoding="UTF-8"\?\>\s.*)' ) {
             if ( $matches[1] -as [xml] ) {
                 $Error = [xml]$matches[1]
-                $ErrorCode = $Error.SelectSingleNode("child::error/errorCode")
+                $ErrorCode = invoke-xpathquery -Node $error -QueryMethod SelectSingleNode -query "child::error/errorCode"
                 if ( $errorCode.'#text' -eq '125023') {
                     write-warning $Error.error.details
                     $ParsedXmlError = $true

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6649,7 +6649,7 @@ function Get-NsxSecondaryManager {
         $content = [xml]$response.content
         if ( invoke-xpathquery -querymethod SelectSingleNode -Query "child::nsxManagerInfos/nsxManagerInfo" -Node $content ) {
             switch ( $PSCmdlet.ParameterSetName ) {
-                "Name" { $content.nsxManagerInfos.nsxManagerInfo  | ? { $_.Name -match $Name}}
+                "Name" { $content.nsxManagerInfos.nsxManagerInfo  | ? { $_.nsxManagerIp -match $Name}}
                 "Uuid" { $content.nsxManagerInfos.nsxManagerInfo | ? { $_.uuid -eq $uuid}}
                 default { $content.nsxManagerInfos.nsxManagerInfo }
             }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6473,7 +6473,7 @@ function Wait-NsxControllerJob {
         "StatusExpression" = {
             $execTask = @()
             $StatusMessage = ""
-            $execTask = $job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "EXECUTING" }
+            $execTask = @($job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "EXECUTING" })
             if ( $exectask.count -eq 1) {
                 $StatusMessage = "Executing Task : $($execTask.name) - $($execTask.taskStatus)"
             }
@@ -6485,7 +6485,7 @@ function Wait-NsxControllerJob {
         "ErrorExpression" = {
             $failTask = @()
             $failMessage = ""
-            $failTask = $job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "FAILED" }
+            $failTask = @($job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "FAILED" })
             if ( $exectask.count -eq 1) {
                 $failMessage = "Failed Task : $($failTask.name) - $($failTask.statusMessage)"
             }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6530,7 +6530,7 @@ function Add-NsxSecondaryManager {
     }
 
     #Validate manager to be added is role standalone
-    $NewMgrConnection = Connect-NsxServer -NsxServer $NsxManager -Credential $Credential -DisableVIAutoConnect -DefaultConnection:$false
+    $NewMgrConnection = Connect-NsxServer -NsxServer $NsxManager -Credential $Credential -DisableVIAutoConnect -DefaultConnection:$false -WarningAction SilentlyContinue
     $NewMgrRole = Get-NsxManagerRole -Connection $NewMgrConnection
     if ( $NewMgrRole.role -ne 'STANDALONE') {
         throw "The specified NSX Manager is currently configured with the role $($NewMgrRole.role) but must be configured as STANDALONE to be added to a Cross VC environment."
@@ -6561,7 +6561,7 @@ function Add-NsxSecondaryManager {
     $URI = "/api/2.0/universalsync/configuration/nsxmanagers"
 
     try  {
-        $response = invoke-nsxwebrequest -method "post" -uri $URI -connection $connection
+        $response = invoke-nsxwebrequest -method "post" -body $NsxManagerInfoElement.OuterXml -uri $URI -connection $connection
         $content = [xml]$response.content
         $content
     }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6398,6 +6398,67 @@ function Get-NsxManagerRole {
 
 }
 
+function Set-NsxManagerRole {
+    <#
+    .SYNOPSIS
+    Sets the NSX Manager Role.
+
+    .DESCRIPTION
+    The NSX Manager is the central management component of VMware NSX for
+    vSphere.
+
+    The Set-NsxManagerRole cmdlet sets the universal sync role of the
+    NSX Manager against which the command is run.
+
+    The only state transitions that are allowed are Standalone (default) to
+    Primary, Secondary to Primary, Primary to StandAlone, or Secondary to
+    StandAlone.
+
+    This cmdlet does not configure a manager as the Secondary role.
+
+    To configure an NSX Manager as secondary, you must use
+    Add-NsxSecondaryManager against the Primary NSX Manager.
+
+    .EXAMPLE
+    Set-NsxManagerRole -Role Primary
+
+    Sets the universal sync role to Primary for the connected NSX Manager
+
+    .EXAMPLE
+    Set-NsxManagerRole -Role StandAlone
+
+    Sets the universal sync role to Standalone for the connected NSX Manager
+
+    #>
+
+    param (
+
+        [Parameter (Mandatory=$True)]
+            #New Role for connected NSX Manager
+            [ValidateSet("Primary", "StandAlone")]
+            [String]$Role,
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+    )
+
+    switch ($role) {
+        "Primary" { $URI = "/api/2.0/universalsync/configuration/role?action=set-as-primary" }
+        "StandAlone" { $URI = "/api/2.0/universalsync/configuration/role?action=set-as-standalone" }
+        Default { Throw "Not Implemented"}
+    }
+
+    try  {
+        $response = invoke-nsxwebrequest -method "post" -uri $URI -connection $connection
+        $content = [xml]$response.content
+        $content.universalSyncRole
+    }
+    Catch {
+        Throw "Failed setting NSX Manager role.  $_"
+    }
+}
+
 function Wait-NsxControllerJob {
 
     <#

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -4620,7 +4620,7 @@ function Wait-NsxJob {
             }
             catch {
                 $StatusString = "Unknown"
-                write-warning "Failed to retrieve job status when waiting for job $jobId.  Please report this error on the PowerNSX github site issues page. (github.com/vmware/PowerNSX/issues)"
+                write-warning "Failed to retrieve job status when waiting for job $jobId.  Please report this error on the PowerNSX issues page. (github.com/vmware/PowerNSX/issues) : $_"
             }
             if ( &$FailCriteria ) {
                 write-debug "$($MyInvocation.MyCommand.Name) : Failure criteria `"$FailCriteria`" evaluated to true."
@@ -4631,7 +4631,7 @@ function Wait-NsxJob {
                 }
                 catch {
                     $ErrorString = "Unknown"
-                    write-warning "Failed to retrieve job error output when job $jobId failed.  Please report this error on the PowerNSX github site issues page. (github.com/vmware/PowerNSX/issues)"
+                    write-warning "Failed to retrieve job error output when job $jobId failed.  Please report this error on the PowerNSX issues page. (github.com/vmware/PowerNSX/issues) : $_"
                 }
 
                 Throw "Job $jobid failed with Status: $StatusString. Error: $ErrorString"

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6478,7 +6478,7 @@ function Wait-NsxControllerJob {
             $failTask = @()
             $failMessage = ""
             $failTask = @($job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "FAILED" })
-            if ( $exectask.count -eq 1) {
+            if ( $failTask.count -eq 1) {
                 $failMessage = "Failed Task : $($failTask.name) - $($failTask.statusMessage)"
             }
             else {
@@ -8172,7 +8172,7 @@ function Wait-NsxTransportZoneJob {
             $failTask = @()
             $failMessage = ""
             $failTask = @($job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "FAILED" })
-            if ( $exectask.count -eq 1) {
+            if ( $failTask.count -eq 1) {
                 $failMessage = "Failed Task : $($failTask.name) - $($failTask.statusMessage)"
             }
             else {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6676,42 +6676,47 @@ function New-NsxController {
                 }
 
                 #Now we check the Controller object in the API - it still needs to come up to running before user has a working control plane...
-                Do {
-                    #Loop while the controller is deploying (not RUNNING)
-                    if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress "Waiting for NSX controller to enter a running state. (Current state: $($Controller.Status)) " }
-                    start-sleep -Seconds 1
+                # Do {
+                #     #Loop while the controller is deploying (not RUNNING)
+                #     if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress "Waiting for NSX controller to enter a running state. (Current state: $($Controller.Status)) " }
+                #     start-sleep -Seconds 1
 
-                    #Try to get the controller object from NSX
-                    try {
-                        $Controller = Get-NsxController -connection $connection -objectid $controllerId
-                    }
-                    catch {
-                        Throw "Controller $controllerId not found when querying NSX.  This means something caused the controller to be removed AFTER the deployment and edge configuration jobs completed successfully.  Check NSX installation tab, and NSX manager logs for the cause."
-                    }
+                #     #Try to get the controller object from NSX
+                #     try {
+                #         $Controller = Get-NsxController -connection $connection -objectid $controllerId
+                #     }
+                #     catch {
+                #         Throw "Controller $controllerId not found when querying NSX.  This means something caused the controller to be removed AFTER the deployment and edge configuration jobs completed successfully.  Check NSX installation tab, and NSX manager logs for the cause."
+                #     }
 
-                    #Make sure it has the props we need to check status!
-                    if ( -not ( Invoke-XpathQuery -QueryMethod SelectSingleNode -query "child::status" -Node $controller )) {
-                        throw "Controller deployment failed.  Status property not available on returned controller object.  Check NSX for more details on cause."
-                    }
+                #     #Make sure it has the props we need to check status!
+                #     if ( -not ( Invoke-XpathQuery -QueryMethod SelectSingleNode -query "child::status" -Node $controller )) {
+                #         throw "Controller deployment failed.  Status property not available on returned controller object.  Check NSX for more details on cause."
+                #     }
 
-                    #Check for a timeout
-                    if ( ((Get-date) - $start).seconds -ge $WaitTimeout ) {
-                        #We exceeded the timeout - what does the user want to do?
-                        $message  = "Waited more than $WaitTimeout seconds for controller to become available.  Recommend checking boot process, network config etc."
-                        $question = "Continue waiting for Controller?"
-                        $decision = $Host.UI.PromptForChoice($message, $question, $yesnochoices, 0)
-                        if ($decision -eq 0) {
-                            #User waits...
-                            $start = get-date
-                        }
-                        else {
-                            throw "Timeout waiting for controller $($controller.id) to become available."
-                        }
-                    }
-                } until  ( $Controller.status -eq 'RUNNING' )
+                #     #Check for a timeout
+                #     if ( ((Get-date) - $start).seconds -ge $WaitTimeout ) {
+                #         #We exceeded the timeout - what does the user want to do?
+                #         $message  = "Waited more than $WaitTimeout seconds for controller to become available.  Recommend checking boot process, network config etc."
+                #         $question = "Continue waiting for Controller?"
+                #         $decision = $Host.UI.PromptForChoice($message, $question, $yesnochoices, 0)
+                #         if ($decision -eq 0) {
+                #             #User waits...
+                #             $start = get-date
+                #         }
+                #         else {
+                #             throw "Timeout waiting for controller $($controller.id) to become available."
+                #         }
+                #     }
+                # } until  ( $Controller.status -eq 'RUNNING' )
 
-                if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress "Waiting for NSX controller to enter a running state. (Current state: $($Controller.Status))" -Completed }
-
+                # if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress "Waiting for NSX controller to enter a running state. (Current state: $($Controller.Status))" -Completed }
+                try {
+                    $Controller = Get-NsxController -connection $connection -objectid $controllerId
+                }
+                catch {
+                    Throw "Controller $controllerId not found when querying NSX.  This means something caused the controller to be removed AFTER the deployment and edge configuration jobs completed successfully.  Check NSX installation tab, and NSX manager logs for the cause."
+                }
                 $Controller
             }
         }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6499,10 +6499,10 @@ function Add-NsxSecondaryManager {
             #Password for NSX Manager to be added.  A local account with SuperUser privileges is required.
             [ValidateNotNullorEmpty()]
             [String]$Password,
-        [Parameter (Mandatory=$True, ParameterSetName="Credential")]
+        [Parameter (Mandatory=$False, ParameterSetName="Credential")]
             #Credential object for NSX Manager to be added.  A local account with SuperUser privileges is required.
             [ValidateNotNullorEmpty()]
-            [String]$Credential = { Get-Credential -Message "NSX Manager admin account" },
+            [pscredential]$Credential = { Get-Credential -Message "NSX Manager admin account" },
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6502,7 +6502,7 @@ function Add-NsxSecondaryManager {
         [Parameter (Mandatory=$False, ParameterSetName="Credential")]
             #Credential object for NSX Manager to be added.  A local account with SuperUser privileges is required.
             [ValidateNotNullorEmpty()]
-            [pscredential]$Credential = { Get-Credential -Message "NSX Manager admin account" },
+            [pscredential]$Credential,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -6522,6 +6522,9 @@ function Add-NsxSecondaryManager {
     }
     else {
         #We need user/pass to generate the xml for the primary NSX Manager.
+        if ( -not $PSBoundParameters.ContainsKey("Credential")) {
+            $Credential = Get-Credential -Message "NSX manager credentials"
+        }
         $UserName = $Credential.Username
         $Password = $Credential.GetNetworkPassword().Password
     }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -2919,7 +2919,34 @@ Function Validate-Controller {
     }
 }
 
+Function Validate-SecondaryManager {
 
+    Param (
+        [Parameter (Mandatory=$true)]
+        [object]$argument
+    )
+
+    if ($argument -is [System.Xml.XmlElement] ) {
+
+        if ( -not ( $argument | get-member -name uuid -Membertype Properties)) {
+            throw "Specify a valid secondary NSX manager."
+        }
+        if ( -not ( $argument | get-member -name nsxManagerIp -Membertype Properties)) {
+            throw "Specify a valid secondary NSX manager."
+        }
+        if ( -not ( $argument | get-member -name isPrimary -Membertype Properties)) {
+            throw "Specify a valid secondary NSX manager."
+        }
+        if ( $argument.isPrimary -eq 'true'){
+            throw "The specified manager has the primary role. Specify a valid secondary NSX manager."
+        }
+
+        $true
+    }
+    else {
+        throw "Specify a valid secondary NSX manager."
+    }
+}
 
 
 ##########
@@ -6592,7 +6619,7 @@ function Get-NsxSecondaryManager {
             #UUID of Nsx Secondary Manager to return
             [ValidateNotNullOrEmpty()]
             [string]$Uuid,
-        [Parameter (Mandatory=$True, ParameterSetName="Name")]
+        [Parameter (Mandatory=$True, ParameterSetName="Name", Position=1)]
             #Name of Nsx Secondary Manager to return
             [ValidateNotNullOrEmpty()]
             [string]$Name,
@@ -6636,28 +6663,13 @@ function Remove-NsxSecondaryManager {
     param (
 
         [Parameter (Mandatory=$True)]
-            #Hostname or IPAddress of the Standalone NSX Manger to be removed
+            #Secondary NSX Manager object to be removed as returned by Get-NsxSecondaryManager
+            [ValidateScript( { Validate-SecondaryManager $_ })]
+            [System.Xml.XmlElement]$SecondaryManager,
+        [Parameter (Mandatory=$True)]
+            #Confirm removal.
             [ValidateNotNullorEmpty()]
-            [String]$NsxManager,
-        [Parameter (Mandatory=$False)]
-            #SHA1 hash of the NSX Manager certificate.  Required unless -AcceptPresentedThumprint is specified.
-            [ValidateNotNullorEmpty()]
-            [String]$Thumbprint,
-        [Parameter (Mandatory=$False)]
-            #Accept any thumbprint presented by the server specified with -NsxManager.  Insecure.
-            [Switch]$AcceptPresentedThumbprint,
-        [Parameter (Mandatory=$False, ParameterSetName="UserPass")]
-            #Username for NSX Manager to be added.  A local account with SuperUser privileges is required.  Defaults to admin.
-            [ValidateNotNullorEmpty()]
-            [String]$Username="admin",
-        [Parameter (Mandatory=$True, ParameterSetName="UserPass")]
-            #Password for NSX Manager to be added.  A local account with SuperUser privileges is required.
-            [ValidateNotNullorEmpty()]
-            [String]$Password,
-        [Parameter (Mandatory=$True, ParameterSetName="Credential")]
-            #Credential object for NSX Manager to be added.  A local account with SuperUser privileges is required.
-            [ValidateNotNullorEmpty()]
-            [String]$Credential = { Get-Credential -Message "NSX Manager admin account" },
+            [switch]$Confirm=$True,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -6665,60 +6677,14 @@ function Remove-NsxSecondaryManager {
     )
 
 
-    #Validate connected Manager is role Primary
-    $ConnectedMgrRole = Get-NsxManagerRole -Connection $Connection
-    if ( $ConnectedMgrRole.role -ne 'PRIMARY') {
-        throw "The connected NSX Manager is currently configure with the role $($ConnectedMgrRole.role), but must be configured as PRIMARY to allow a secondary NSX Manager to be added to it."
-    }
 
-    #Build cred object for default auth if user specified username/pass
-    if ($PSCmdlet.ParameterSetName = "UserPass" ) {
-        $Credential = new-object System.Management.Automation.PSCredential($Username, $(ConvertTo-SecureString $Password -AsPlainText -Force))
-    }
-    else {
-        #We need user/pass to generate the xml for the primary NSX Manager.
-        $UserName = $Credential.Username
-        $Password = $Credential.GetNetworkPassword().Password
-    }
-
-    #Validate manager to be added is role standalone
-    $NewMgrConnection = Connect-NsxServer -NsxServer $NsxManager -Credential $Credential -DisableVIAutoConnect -DefaultConnection:$false
-    $NewMgrRole = Get-NsxManagerRole -Connection $NewMgrConnection
-    if ( $NewMgrRole.role -ne 'STANDALONE') {
-        throw "The specified NSX Manager is currently configured with the role $($NewMgrRole.role) but must be configured as STANDALONE to be added to a Cross VC environment."
-    }
-
-    #Make sure we have a thumbprint
-    if ( $AcceptPresentedThumbprint ) {
-        #Get the cert thumbprint of the specified manager.
-        try {
-            $Cert = Get-NsxManagerCertificate -Connection $Connection
-            $Thumbprint = $Cert.Sha1Hash
-        }
-        catch {
-            throw "Failed retrieving the certificate thumbprint from the specified NSX manager.  $_"
-        }
-    }
-    elseif ( -not $PSBoundParameters.ContainsKey("Thumbprint")) {
-        throw "The Thumbprint of the NSX Manager to be added as secondary must be specified, or -AcceptPresentedThumbprint specified (insecure)."
-    }
-
-    $XmlDoc = New-Object System.Xml.XmlDocument
-    $NsxManagerInfoElement = $XmlDoc.CreateElement("nsxManagerInfo")
-    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName nsxManagerIp -xmlElementText $NsxManager
-    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName nsxManagerUsername -xmlElementText $UserName
-    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName nsxManagerPassword -xmlElementText $Password
-    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName certificateThumbprint -xmlElementText $Thumbprint
-
-    $URI = "/api/2.0/universalsync/configuration/nsxmanagers"
+    $URI = "/api/2.0/universalsync/configuration/nsxmanagers/$($SecondaryManager.uuid)"
 
     try  {
-        $response = invoke-nsxwebrequest -method "post" -uri $URI -body $NsxManagerInfoElement -connection $connection
-        $content = [xml]$response.content
-        $content
+        $response = invoke-nsxwebrequest -method "delete" -uri $URI -connection $connection
     }
     Catch {
-        Throw "Failed adding secondary NSX Manager.  $_"
+        Throw "Failed removing secondary NSX Manager.  $_"
     }
 }
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6475,7 +6475,7 @@ function Wait-NsxControllerJob {
             $StatusMessage = ""
             $execTask = @($job.jobinstances.jobInstance.taskInstances.taskInstance | where-object { $_.taskStatus -eq "EXECUTING" })
             if ( $exectask.count -eq 1) {
-                $StatusMessage = "Executing Task : $($execTask.name) - $($execTask.taskStatus)"
+                $StatusMessage = "$($execTask.name) - $($execTask.taskStatus)"
             }
             else {
                 $StatusMessage = "$($job.jobinstances.jobInstance.Status)"

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6485,7 +6485,7 @@ function Set-NsxManagerRole {
             if ( $matches[1] -as [xml] ) {
                 $Error = [xml]$matches[1]
                 $ErrorCode = $Error.SelectSingleNode("child::error/errorCode")
-                if ( $errorCode -eq '125023') {
+                if ( $errorCode.'#text' -eq '125023') {
                     write-warning $Error.error.details
                     $ParsedXmlError = $true
                 }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6540,7 +6540,7 @@ function Add-NsxSecondaryManager {
     if ( $AcceptPresentedThumbprint ) {
         #Get the cert thumbprint of the specified manager.
         try {
-            $Cert = Get-NsxManagerCertificate -Connection $Connection
+            $Cert = Get-NsxManagerCertificate -Connection $NewMgrConnection
             $Thumbprint = $Cert.Sha1Hash
         }
         catch {

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6585,8 +6585,17 @@ function Get-NsxSecondaryManager {
 
     #>
 
+    [CmdletBinding(DefaultParameterSetName="Default")]
     param (
 
+        [Parameter (Mandatory=$True, ParameterSetName="uuid")]
+            #UUID of Nsx Secondary Manager to return
+            [ValidateNotNullOrEmpty()]
+            [string]$Uuid,
+        [Parameter (Mandatory=$True, ParameterSetName="Name")]
+            #Name of Nsx Secondary Manager to return
+            [ValidateNotNullOrEmpty()]
+            [string]$Name,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -6597,7 +6606,12 @@ function Get-NsxSecondaryManager {
     $response = invoke-nsxwebrequest -method "get" -uri $URI -connection $connection
     try {
         $content = [xml]$response.content
-        $content
+        switch ( $PSCmdlet.ParamaterSetName ) {
+
+            "Name" { $content.nsxManagerInfos.nsxManagerInfo  | ? { $_.Name -match $Name}}
+            "Uuid" { $content.nsxManagerInfos.nsxManagerInfo | ? { $_.uuid -eq $uuid}}
+            default { $content.nsxManagerInfos.nsxManagerInfo }
+        }
     }
     catch {
         throw "Unable to retrieve secondary NSX Manager information. $_"

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6567,6 +6567,144 @@ function Add-NsxSecondaryManager {
     }
 }
 
+function Get-NsxSecondaryManager {
+    <#
+    .SYNOPSIS
+    Gets configured secondary NSX Managers from the connected NSX Manager.
+
+    .DESCRIPTION
+    The NSX Manager is the central management component of VMware NSX for
+    vSphere.
+
+    If run against a primary NSX Manager, the Get-NsxSecondaryManager cmdlet
+    retrieves configured secondary NSX managers.  If run against a secondary
+    NSX Manager, information about the configured primary is returned.
+
+    #>
+
+    param (
+
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+    )
+
+    $URI = "/api/2.0/universalsync/configuration/nsxmanagers"
+    $response = invoke-nsxwebrequest -method "get" -uri $URI -connection $connection
+    try {
+        $content = [xml]$response.content
+        $content
+    }
+    catch {
+        throw "Unable to retrieve secondary NSX Manager information. $_"
+    }
+}
+
+function Remove-NsxSecondaryManager {
+    <#
+    .SYNOPSIS
+    Removes a secondary NSX Manager from a CrossVC configured NSX
+    environment.
+
+    .DESCRIPTION
+    The NSX Manager is the central management component of VMware NSX for
+    vSphere.
+
+    The Remove-NsxSecondaryManager cmdlet removes a secondary NSX Manager
+    from a CrossVC configured NSX environment.
+
+    #>
+
+    param (
+
+        [Parameter (Mandatory=$True)]
+            #Hostname or IPAddress of the Standalone NSX Manger to be removed
+            [ValidateNotNullorEmpty()]
+            [String]$NsxManager,
+        [Parameter (Mandatory=$False)]
+            #SHA1 hash of the NSX Manager certificate.  Required unless -AcceptPresentedThumprint is specified.
+            [ValidateNotNullorEmpty()]
+            [String]$Thumbprint,
+        [Parameter (Mandatory=$False)]
+            #Accept any thumbprint presented by the server specified with -NsxManager.  Insecure.
+            [Switch]$AcceptPresentedThumbprint,
+        [Parameter (Mandatory=$False, ParameterSetName="UserPass")]
+            #Username for NSX Manager to be added.  A local account with SuperUser privileges is required.  Defaults to admin.
+            [ValidateNotNullorEmpty()]
+            [String]$Username="admin",
+        [Parameter (Mandatory=$True, ParameterSetName="UserPass")]
+            #Password for NSX Manager to be added.  A local account with SuperUser privileges is required.
+            [ValidateNotNullorEmpty()]
+            [String]$Password,
+        [Parameter (Mandatory=$True, ParameterSetName="Credential")]
+            #Credential object for NSX Manager to be added.  A local account with SuperUser privileges is required.
+            [ValidateNotNullorEmpty()]
+            [String]$Credential = { Get-Credential -Message "NSX Manager admin account" },
+        [Parameter (Mandatory=$False)]
+            #PowerNSX Connection object
+            [ValidateNotNullOrEmpty()]
+            [PSCustomObject]$Connection=$defaultNSXConnection
+    )
+
+
+    #Validate connected Manager is role Primary
+    $ConnectedMgrRole = Get-NsxManagerRole -Connection $Connection
+    if ( $ConnectedMgrRole.role -ne 'PRIMARY') {
+        throw "The connected NSX Manager is currently configure with the role $($ConnectedMgrRole.role), but must be configured as PRIMARY to allow a secondary NSX Manager to be added to it."
+    }
+
+    #Build cred object for default auth if user specified username/pass
+    if ($PSCmdlet.ParameterSetName = "UserPass" ) {
+        $Credential = new-object System.Management.Automation.PSCredential($Username, $(ConvertTo-SecureString $Password -AsPlainText -Force))
+    }
+    else {
+        #We need user/pass to generate the xml for the primary NSX Manager.
+        $UserName = $Credential.Username
+        $Password = $Credential.GetNetworkPassword().Password
+    }
+
+    #Validate manager to be added is role standalone
+    $NewMgrConnection = Connect-NsxServer -NsxServer $NsxManager -Credential $Credential -DisableVIAutoConnect -DefaultConnection:$false
+    $NewMgrRole = Get-NsxManagerRole -Connection $NewMgrConnection
+    if ( $NewMgrRole.role -ne 'STANDALONE') {
+        throw "The specified NSX Manager is currently configured with the role $($NewMgrRole.role) but must be configured as STANDALONE to be added to a Cross VC environment."
+    }
+
+    #Make sure we have a thumbprint
+    if ( $AcceptPresentedThumbprint ) {
+        #Get the cert thumbprint of the specified manager.
+        try {
+            $Cert = Get-NsxManagerCertificate -Connection $Connection
+            $Thumbprint = $Cert.Sha1Hash
+        }
+        catch {
+            throw "Failed retrieving the certificate thumbprint from the specified NSX manager.  $_"
+        }
+    }
+    elseif ( -not $PSBoundParameters.ContainsKey("Thumbprint")) {
+        throw "The Thumbprint of the NSX Manager to be added as secondary must be specified, or -AcceptPresentedThumbprint specified (insecure)."
+    }
+
+    $XmlDoc = New-Object System.Xml.XmlDocument
+    $NsxManagerInfoElement = $XmlDoc.CreateElement("nsxManagerInfo")
+    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName nsxManagerIp -xmlElementText $NsxManager
+    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName nsxManagerUsername -xmlElementText $UserName
+    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName nsxManagerPassword -xmlElementText $Password
+    Add-XmlElement -xmlRoot $NsxManagerInfoElement -xmlElementName certificateThumbprint -xmlElementText $Thumbprint
+
+    $URI = "/api/2.0/universalsync/configuration/nsxmanagers"
+
+    try  {
+        $response = invoke-nsxwebrequest -method "post" -uri $URI -body $NsxManagerInfoElement -connection $connection
+        $content = [xml]$response.content
+        $content
+    }
+    Catch {
+        Throw "Failed adding secondary NSX Manager.  $_"
+    }
+}
+
 function Wait-NsxControllerJob {
 
     <#

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6606,7 +6606,7 @@ function Get-NsxSecondaryManager {
     $response = invoke-nsxwebrequest -method "get" -uri $URI -connection $connection
     try {
         $content = [xml]$response.content
-        switch ( $PSCmdlet.ParamaterSetName ) {
+        switch ( $PSCmdlet.ParameterSetName ) {
 
             "Name" { $content.nsxManagerInfos.nsxManagerInfo  | ? { $_.Name -match $Name}}
             "Uuid" { $content.nsxManagerInfos.nsxManagerInfo | ? { $_.uuid -eq $uuid}}

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6456,9 +6456,7 @@ function Wait-NsxControllerJob {
 
     #Now, we check the edge job status...
     write-debug "$($MyInvocation.MyCommand.Name) : Calling Wait-NsxJob for Edge Job."
-    Wait-NsxJob -jobid $jobid -JobStatusUri "/api/4.0/edges/jobs" -CompleteCriteria { $job.edgeJob.status -eq "COMPLETED" } -FailCriteria { $job.edgeJob.status -eq "FAILED" } -StatusExpression { $job.edgeJob.message } -WaitTimeout ($WaitTimeout - $elapsed) -FailOnTimeout:$FailOnTimeout
-
-
+    Wait-NsxJob -jobid $jobid -JobStatusUri "/api/4.0/edges/jobs" -CompleteCriteria { $job.edgeJob.status -eq "COMPLETED" } -FailCriteria { $job.edgeJob.status -eq "FAILED" } -StatusExpression { $job.edgeJob.status } -ErrorExpression { $job.edgeJob.message } -WaitTimeout ($WaitTimeout - $elapsed) -FailOnTimeout:$FailOnTimeout
 
 }
 

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -8219,7 +8219,7 @@ function Add-NsxTransportZoneMember {
             #Block until transport zone update job is 'COMPLETED' (Will timeout with prompt after -WaitTimeout seconds)
             #Useful if automating the tz modification so you dont have to write looping code to check status of the tz before continuing.
             #NOTE: Not waiting means we do NOT return an updated tz object!
-            [switch]$Wait=$false,
+            [switch]$Wait=$True,
         [Parameter ( Mandatory=$False)]
             #Timeout waiting for tz update job to complete before user is prompted to continue or cancel. Defaults to 30 seconds.
             [int]$WaitTimeout = 30,
@@ -8314,7 +8314,7 @@ function Remove-NsxTransportZoneMember {
             #Block until transport zone update job is 'COMPLETED' (Will timeout with prompt after -WaitTimeout seconds)
             #Useful if automating the tz modification so you dont have to write looping code to check status of the tz before continuing.
             #NOTE: Not waiting means we do NOT return an updated tz object!
-            [switch]$Wait=$false,
+            [switch]$Wait=$True,
         [Parameter ( Mandatory=$False)]
             #Timeout waiting for tz update job to complete before user is prompted to continue or cancel. Defaults to 30 seconds.
             [int]$WaitTimeout = 30,

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6481,7 +6481,7 @@ function Set-NsxManagerRole {
     }
     Catch {
         $ParsedXmlError = $false
-        if ( $_ -match '.*(<?xml version="1.0" encoding="UTF-8"?>.*)' ) {
+        if ( $_ -match '.*(\<\?xml version="1\.0" encoding="UTF-8"\?\>\s.*)' ) {
             if ( $matches[1] -as [xml] ) {
                 $Error = [xml]$matches[1]
                 $ErrorCode = $Error.SelectSingleNode("child::error/errorCode")

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -4593,7 +4593,7 @@ function Wait-NsxJob {
         do {
 
             #Sleep
-            if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -Activity "Processing" -Status "Waiting for NSX job $jobId to complete.  Current status: $StatusString" }
+            if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -Activity "Waiting for NSX job $jobId to complete." -Status "$StatusString" }
             start-sleep -Seconds $SleepSeconds
             $Timer += $SleepSeconds
 
@@ -4639,7 +4639,7 @@ function Wait-NsxJob {
         } until ( &$CompleteCriteria )
         write-debug "$($MyInvocation.MyCommand.Name) : Completed criteria `"$CompleteCriteria`" evaluated to true."
 
-        if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -Activity "Processing" -Status "Waiting for NSX job $jobId to complete.  Current status: $StatusString" -Completed  }
+        if ($script:PowerNSXConfiguration.ProgressDialogs) {  Write-Progress -Activity "Waiting for NSX job $jobId to complete." -Status "$StatusString" -Completed  }
     }
 
     end {}

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -4590,7 +4590,7 @@ function Wait-NsxJob {
         $Timer = 0
 
         #Now - loop, checking job status
-        while ( -not (&$CompleteCriteria) ) {
+        do {
 
             #Sleep
             if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -Activity "Processing" -Status "Waiting for NSX job $jobId to complete.  Current status: $StatusString" }
@@ -4636,7 +4636,7 @@ function Wait-NsxJob {
 
                 Throw "Job $jobid failed with Status: $StatusString. Error: $ErrorString"
             }
-        }
+        } until ( &$CompleteCriteria )
         write-debug "$($MyInvocation.MyCommand.Name) : Completed criteria `"$CompleteCriteria`" evaluated to true."
 
         if ($script:PowerNSXConfiguration.ProgressDialogs) { Write-Progress -Activity "Processing" -Status "Waiting for NSX job $jobId to complete.  Current status: $StatusString" -Completed  }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6434,8 +6434,8 @@ function Wait-NsxControllerJob {
             #Job Id string as returned from the api
             [string]$JobId,
         [Parameter (Mandatory=$false)]
-            #Seconds to wait before declaring a timeout
-            [int]$WaitTimeout=300,
+            #Seconds to wait before declaring a timeout.  Timeout defaults to 720 seconds, which is longer than the NSX internal timeout and rollback of a failed controller deployment.
+            [int]$WaitTimeout=720,
         [Parameter (Mandatory=$false)]
             #Do we prompt user an allow them to reset the timeout timer, or throw on timeout
             [switch]$FailOnTimeout=$false,
@@ -6463,7 +6463,7 @@ function Wait-NsxControllerJob {
 
     $WaitJobArgs = @{
         "jobid" = $jobid
-        "JobStatusUri" = "/api/2.0/services/taskservice/job/"
+        "JobStatusUri" = "/api/2.0/services/taskservice/job"
         "CompleteCriteria" = {
             $job.jobInstances.jobInstance.status -eq "COMPLETED"
         }

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6526,7 +6526,7 @@ function Add-NsxSecondaryManager {
             $Credential = Get-Credential -Message "NSX manager credentials"
         }
         $UserName = $Credential.Username
-        $Password = $Credential.GetNetworkPassword().Password
+        $Password = $Credential.GetNetworkCredential().Password
     }
 
     #Validate manager to be added is role standalone

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -4586,7 +4586,7 @@ function Wait-NsxJob {
 
         write-debug "$($MyInvocation.MyCommand.Name) : Waiting for job $jobid"
 
-        $StatusString = $null
+        $StatusString = "Unknown"
         $Timer = 0
 
         #Now - loop, checking job status
@@ -4645,9 +4645,6 @@ function Wait-NsxJob {
     end {}
 
 }
-
-
-
 
 #########
 #########
@@ -8121,14 +8118,14 @@ function Wait-NsxTransportZoneJob {
     .EXAMPLE
     Wait-NsxTransportZoneJob -Jobid jobdata-1234
 
-    Wait for transportzone job jobdata-1234 up to 30 seconds to complete
-    successfully or fail.  If 30 seconds elapse, then prompt for action.
+    Wait for transportzone job jobdata-1234 up to the default of 30 seconds to
+    complete successfully or fail.  If 30 seconds elapse, then prompt for action.
 
     .EXAMPLE
-    Wait-NsxTransportZoneJob -Jobid jobdata-1234 -TimeOut 30 -FailOnTimeOut
+    Wait-NsxTransportZoneJob -Jobid jobdata-1234 -TimeOut 40 -FailOnTimeOut
 
     Wait for transportzone job jobdata-1234 up to 40 seconds to complete
-    successfully or fail.  If 400 seconds elapse, then throw an error.
+    successfully or fail.  If 40 seconds elapse, then throw an error.
 
     #>
 
@@ -8185,6 +8182,7 @@ function Wait-NsxTransportZoneJob {
         }
         "WaitTimeout" = $WaitTimeout
         "FailOnTimeout" = $FailOnTimeout
+        "Connection" = $Connection
     }
 
     Wait-NsxJob @WaitJobArgs

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6662,7 +6662,7 @@ function Remove-NsxSecondaryManager {
 
     param (
 
-        [Parameter (Mandatory=$True)]
+        [Parameter (Mandatory=$True, ValueFromPipeline=$true)]
             #Secondary NSX Manager object to be removed as returned by Get-NsxSecondaryManager
             [ValidateScript( { Validate-SecondaryManager $_ })]
             [System.Xml.XmlElement]$SecondaryManager,

--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -6567,14 +6567,14 @@ function New-NsxController {
             #Controller Password (Must be same on all controllers)
             [string]$Password,
         [Parameter ( Mandatory=$False)]
-            #Block until Controller Status in API is 'RUNNING' (Will timeout with prompt after -WaitTimeout seconds)
+            #Block until Controller deployment job is 'COMPLETED' (Will timeout with prompt after -WaitTimeout seconds)
             #Useful if automating the deployment of multiple controllers (first must be running before deploying second controller)
             #so you dont have to write looping code to check status of controller before continuing.
             #NOTE: Not waiting means we do NOT return a controller object!
             [switch]$Wait=$false,
         [Parameter ( Mandatory=$False)]
-            #Timeout waiting for controller to become 'RUNNING' before user is prompted to continue or cancel.
-            [int]$WaitTimeout = 600,
+            #Timeout waiting for controller to become 'RUNNING' before user is prompted to continue or cancel. Defaults to 720 seconds to exceed the normal NSX rollback timeout of 600 seconds.
+            [int]$WaitTimeout = 720,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -6662,7 +6662,7 @@ function New-NsxController {
 
                 #First we wait for NSX job framework to give us the needful
                 try {
-                    Wait-NsxControllerJob -Jobid $JobID -Connection $Connection
+                    Wait-NsxControllerJob -Jobid $JobID -Connection $Connection -WaitTimeout $WaitTimeout
                     Get-NsxController -connection $connection -objectid $controllerId
                 }
                 catch {
@@ -6762,6 +6762,11 @@ function Remove-NsxController {
         [Parameter (Mandatory=$False)]
             #Prompt for confirmation.  Specify as -confirm:$false to disable confirmation prompt
             [switch]$Confirm=$true,
+        [Parameter ( Mandatory=$False)]
+            #Block until Controller Removal job is COMPLETED (Will timeout with prompt after 720 seconds)
+            #Useful if automating the removal of multiple controllers (first must be removed before removing second controller)
+            #so you dont have to write looping code to check status of controller before continuing.
+            [switch]$Wait=$false,
         [Parameter (Mandatory=$false)]
             #Force the removal of the last controller.  WARNING THIS WILL IMPACT LOGICAL SWITCHING AND ROUTING FUNCTIONALITY
             [switch]$Force=$false,

--- a/tests/integration/02.LogicalSwitch.Tests.ps1
+++ b/tests/integration/02.LogicalSwitch.Tests.ps1
@@ -12,6 +12,7 @@ Describe "Logical Switching" {
         import-module $pnsxmodule
         $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:ls1_name = "pester_ls_ls1"
+
     }
 
     it "Can retrieve a transport zone" {
@@ -27,6 +28,77 @@ Describe "Logical Switching" {
     it "Can remove a logical switch"{
         get-nsxlogicalswitch $ls1_name | Remove-NsxLogicalSwitch -Confirm:$false
         get-nsxlogicalswitch $ls1_name | should be $null
+    }
+
+    Context "Transport Zone Tests" {
+        BeforeAll {
+            $script:tz = Get-NsxTransportZone | select -first 1
+            $emptycl = ($tz).clusters.cluster.cluster.name | % {get-cluster $_ } | ? { ($_ | get-vm | measure).count -eq 0 }
+            if ( -not $emptycl ) {
+                write-warning "No cluster that is a member of an NSX TransportZone but not hosting any VMs could be found for Transport Zone membership addition/removal tests."
+                $script:SkipTzMember = $True
+            }
+            else {
+                $script:cl = $emptycl | select -First 1
+                $script:SkipTzMember = $False
+                write-warning "Using cluster $cl for transportzone membership test"
+            }
+        }
+
+        AfterEach {
+            if ( $SkipTzMember ) {
+                $CurrentTz = Get-NsxTransportZone -objectid $tz.objectId
+                if ( $CurrentTz.Clusters.Cluster.Cluster.objectId -notcontains $cl.objectId ) {
+                    #Cluster has been removed, and needs to be readded...
+                    $CurrentTz | Add-NsxTransportZoneMember -Cluster $cl -Wait
+                }
+            }
+        }
+
+        Context "Transport Zone Cluster Addition" {
+
+            it "Can remove a transportzone cluster - async" -skip:$SkipTzMember {
+                $tz | Remove-NsxTransportZoneMember -Cluster $cl
+                $updatedtz = Get-NsxTransportZone -objectId $tz.objectId
+                $updatedtz | should be $null
+                $CurrentTz = Get-NsxTransportZone -objectid $tz.objectId
+                $CurrentTz.clusters.cluster.cluster.name -contains $cl.name | should be $false
+            }
+
+            it "Can remove a transportzone cluster - synch" -skip:$SkipTzMember {
+                $tz | Remove-NsxTransportZoneMember -Cluster $cl
+                $updatedtz = Get-NsxTransportZone -objectId $tz.objectId
+                $updatedtz.clusters.cluster.cluster.name -contains $cl.name | should be $false
+            }
+        }
+
+        Context "Transport Zone Cluster Addition" {
+            BeforeEach {
+                if ( $SkipTzMember ) {
+                    $CurrentTz = Get-NsxTransportZone -objectid $tz.objectId
+                    if ( $CurrentTz.Clusters.Cluster.Cluster.objectId -contains $cl.objectId ) {
+                        #Cluster has been added, and needs to be removed...
+                        $CurrentTz | Remove-NsxTransportZoneMember -Cluster $cl -Wait
+                    }
+                }
+            }
+
+            it "Can add a transportzone cluster - async" -skip:$SkipTzMember {
+                $tz | Add-NsxTransportZoneMember -Cluster $cl
+                $updatedtz = Get-NsxTransportZone -objectId $tz.objectId
+                $updatedtz | should be $null
+                $CurrentTz = Get-NsxTransportZone -objectid $tz.objectId
+                $CurrentTz.clusters.cluster.cluster.name -contains $cl.name | should be $true
+
+            }
+
+            it "Can add a transportzone cluster - synch" -skip:$SkipTzMember {
+                $tz | Add-NsxTransportZoneMember -Cluster $cl
+                $updatedtz = Get-NsxTransportZone -objectId $tz.objectId
+                $updatedtz.clusters.cluster.cluster.name -contains $cl.name | should be $true
+            }
+        }
+
     }
 
     AfterAll {

--- a/tests/integration/15.Controller.Tests.ps1
+++ b/tests/integration/15.Controller.Tests.ps1
@@ -1,0 +1,51 @@
+#Do not remove this - we need to ensure connection setup and module deps preload have occured.
+If ( -not $PNSXTestVC ) {
+    Throw "Tests must be invoked via Start-Test function from the Test module.  Import the Test module and run Start-Test"
+}
+
+Describe "Controller" {
+
+    BeforeAll {
+
+        #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
+        #We load the mod and establish connection to NSX Manager here.
+        import-module $pnsxmodule
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:ctrl = Get-NsxController
+        if ( @($ctrl).count -ne 1) {
+            $script:SkipCtrlTest = $True
+            write-warning "NSX Controller tests disabled.  Ensure only a single controller is deployed to enable controller tests."
+        }
+        else {
+            $ctrlview = Get-View "$($Ctrl.virtualMachineInfo.objectTypeName)-$($Ctrl.virtualMachineInfo.objectId)" -Property Network,Datastore,resourcepool
+            $script:rp = Get-ResourcePool -Id ("$($ctrlview.ResourcePool.type)-$($ctrlview.ResourcePool.Value)")
+            $script:pg = Get-VdPortGroup -Id ("$($ctrlview.Network.type)-$($ctrlview.Network.Value)")
+            $script:ds = Get-Datastore -Id ("$($ctrlview.Datastore.type)-$($ctrlview.Datastore.Value)")
+
+            #Yup - this is dodgy... going to create Find-NsxControllerIpPool using ip matchs to search existing pools one of these days, as you cant reverse engineer this from the controller API response. :(
+            $script:pool = Get-NSxIpPool | ? { $_.name -match "controller" }
+            write-warning "Using existing controller ds, portgroup and resourcepool config for additional controller deployment"
+            $script:SkipCtrlTest = $False
+        }
+    }
+
+    It "Can deploy a controller - Sync" -Skip:$SkipCtrlTest {
+        $newctrl = New-NsxController -IpPool $pool -ControllerName pester_test_ctrl_1 -ResourcePool $rp -Datastore $ds -PortGroup $pg -wait
+        $currentCtrl = Get-NsxController -ObjectId $newctrl.objectid
+        $currentCtrl | should notbe $null
+        $currentCtrl.status | should be "RUNNING"
+    }
+
+    It "Can remove a controller - Sync" -Skip:$SkipCtrlTest {
+        $ctrlToRemove = Get-NSxController | ? { $_.objectId -ne $ctrl.objectId }
+        {$CtrlToRemove | Remove-NsxController -Wait } | should not throw
+        Get-NsxController -ObjectId $ctrlToRemove.objectid  | should be $null
+    }
+    AfterAll {
+
+        #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
+        #We kill the connection to NSX Manager here.
+        disconnect-nsxserver
+    }
+}
+


### PR DESCRIPTION
- Refactored Job Wait code from New-NsxController again.  Required to avoid duplicate code in Transport Zone Member manipulation cmdlets.
- Added Wait-NsxJob generic cmdlet that allows easy(er) interaction with the various NSX task frameworks
- Added Add/Remove-NsxTransportZoneMember to manipulate the clusters configured in a given transport zone
- Added Set-NsxManagerRole to allow manipulation of an NSX managers universal sync role
- Added Add-NsxSecondaryManager to allow addition of an NSX manager to a Cross VC Primary NSX manager
- Added Get and Remove-NsxSecondaryManager
- Added Invoke-NsxManagerSync to allow triggering of universal replication
- Added Get-NsxManagerSyncStatus to check the synchronisation status of a primary NSX manager

This PR addresses all required functionality to manipulate NSX manager roles and manipulate transport zone membership in a cross VC environment,