### PR TITLE
Nat tests

### DIFF
--- a/PowerNSX.psm1
+++ b/PowerNSX.psm1
@@ -3956,6 +3956,10 @@ function Connect-NsxServer {
             #vCenter Server address or FQDN (not NSX Manager!).  Used to determine NSX Server endpoint and authenticate using SSO credentials.  Recommended method.
             [ValidateNotNullOrEmpty()]
             [string]$vCenterServer,
+        [Parameter (Mandatory=$true, ParameterSetName="vCenterServer", DontShow)]
+            #NSX Manager address used to override that registered in vCenter.  Used for scenarios where NSX manager is behind a NAT device.
+            [ValidateNotNullOrEmpty()]
+            [string]$NsxServerHint,
         [Parameter (Mandatory=$false)]
             #TCP Port to connect to on -Server
             [ValidateRange(1,65535)]
@@ -4281,7 +4285,12 @@ function Connect-NsxServer {
                 throw "Server information for the registered NSX solution could not be retreived.  Raw endpoint URL $($NSXExtension.Client.Url)"
             }
 
-            $NsxServer = $ServerCol[0]
+            if ( $PSBoundParameters.ContainsKey("NsxServerHint")) {
+                $NsxServer = $NsxServerHint
+            }
+            else {
+                $NsxServer = $ServerCol[0]
+            }
             $Port = $ServerCol[1]
 
             $ProtocolCol = $EndpointCol[0] -split ":"

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -3,11 +3,9 @@
 
 # Must load via manifest file otherwise dep module loads dont occur properly
 # Must have separate test manifest for core now :(
-
-
 #We can drop a connection file that allows future non interactive invocation
+
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$cxnfile = "$here\Test.cxn"
 
 $ynchoices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
 $ynchoices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
@@ -20,11 +18,21 @@ $pnsxmodule = "$there\$sut"
 function Start-Test {
     #Sets up credentials and performs other stuff before invoking pester
     param (
-        $testname
+        #Optional subset Test context to execute
+        $testname,
+        #Absolute path to alternative connection file.  Defaults to tests/Text.cxn
+        $ConnectionFile
     )
 
     get-module PowerNSX | remove-module
     Import-Module $pnsxmodule -ErrorAction Stop -global
+
+    if ( $ConnectionFile ) {
+        $cxnfile = $ConnectionFile
+    }
+    else {
+        $cxnfile = "$here\Test.cxn"
+    }
 
     if ( -not (test-path $cxnfile )) {
 

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -114,7 +114,7 @@ function Start-Test {
 
     #Do the needful after testing and validating that the env is suitable for running tests testing.
 
-    write-host -forgroundcolor Green "Executing tests against VC $PNSXTestVC and NSX $PNSXTestNSX"
+    write-host -foregroundcolor Green "Executing tests against VC $PNSXTestVC and NSX $PNSXTestNSX"
 
     $result = invoke-pester -PassThru -Tag "Environment"
     if ( $result.failedcount -eq 0) {

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -116,11 +116,12 @@ function Start-Test {
 
     write-host -foregroundcolor Green "Executing tests against VC $PNSXTestVC and NSX $PNSXTestNSX from connection file : $cxnfile"
 
-    $result = invoke-pester -PassThru -Tag "Environment"
+    $result = invoke-pester -PassThru -Tag "Environment" -EnableExit
     if ( $result.failedcount -eq 0) {
         $pestersplat = @{
             "testname" = $testname
             "ExcludeTag" = "Environment"
+            "EnableExit" = $true
         }
         invoke-pester @pestersplat
     }

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -17,8 +17,6 @@ $there = Split-Path -Parent $MyInvocation.MyCommand.Path | split-path -parent
 $sut = "PowerNSX.psd1"
 $pnsxmodule = "$there\$sut"
 
-
-
 function Start-Test {
     #Sets up credentials and performs other stuff before invoking pester
     param (
@@ -34,6 +32,7 @@ function Start-Test {
         write-warning "No saved connection details found, prompting user."
         # $PNSXTestNSXManager = read-host "NSX Manager Ip/Name"
         $PNSXTestVC = read-host "vCenter Server Ip/Name"
+        $PNSXTestNSX = read-host "NSX Server (If NSX is behind NAT, enter the NATed address here)"
         $PNSXTestDefMgrUsername = "admin"
         $PNSXTestDefMgrPassword = read-host "NSX Manager admin password"
 
@@ -56,7 +55,7 @@ function Start-Test {
         if ( $decision -eq 0 ) {
             [pscustomobject]$export = @{
                 "vc" = $PNSXTestVC;
-
+                "nsx" = $PNSXTestNSX;
 
                 ###
                 #PowerShell Core has bug in ConvertFrom-SecureString that means we cant persist encrypted credentials to disk.
@@ -87,11 +86,12 @@ function Start-Test {
             $_
         }
 
-        if ( -not ( $import.vc -and $import.nsxuser -and $import.nsxpwd -and $import.viuser -and $import.vipwd )) {
+        if ( -not ( $import.vc -and $import.nsx -and $import.nsxuser -and $import.nsxpwd -and $import.viuser -and $import.vipwd )) {
             throw "Import file does not contain required connection information.  Delete existing file and try again."
         }
 
         $PNSXTestVC = $import.vc
+        $PNSXTestNSX = $import.nsx
 
         ###
         #PowerShell Core has bug in ConvertFrom-SecureString that means we cant persist encrypted credentials to disk.

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -114,7 +114,7 @@ function Start-Test {
 
     #Do the needful after testing and validating that the env is suitable for running tests testing.
 
-    write-host -foregroundcolor Green "Executing tests against VC $PNSXTestVC and NSX $PNSXTestNSX"
+    write-host -foregroundcolor Green "Executing tests against VC $PNSXTestVC and NSX $PNSXTestNSX from connection file : $cxnfile"
 
     $result = invoke-pester -PassThru -Tag "Environment"
     if ( $result.failedcount -eq 0) {

--- a/tests/Test.psm1
+++ b/tests/Test.psm1
@@ -113,6 +113,9 @@ function Start-Test {
     }
 
     #Do the needful after testing and validating that the env is suitable for running tests testing.
+
+    write-host -forgroundcolor Green "Executing tests against VC $PNSXTestVC and NSX $PNSXTestNSX"
+
     $result = invoke-pester -PassThru -Tag "Environment"
     if ( $result.failedcount -eq 0) {
         $pestersplat = @{

--- a/tests/integration/01.Environment.Tests.ps1
+++ b/tests/integration/01.Environment.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Environment" -Tags "Environment" {
 
     it "Establishes a default PowerNSX Connection" {
         # Using VI based SSO connection now.
-        $global:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $global:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
     }
 
     it "Can find a VI cluster to deploy to" {

--- a/tests/integration/02.LogicalSwitch.Tests.ps1
+++ b/tests/integration/02.LogicalSwitch.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Logical Switching" {
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
         #We load the mod and establish connection to NSX Manager here.
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         # Prefix to use for different variables.
         $script:tzPrefix = "pester_tz"
         $script:lsPrefix = "pester_ls"

--- a/tests/integration/03.LogicalRouter.Tests.ps1
+++ b/tests/integration/03.LogicalRouter.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Logical Routing" {
         #We load the mod, establish connection to NSX Manager and do any local variable definitions here
 
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for logical router appliance deployment"
 

--- a/tests/integration/04.Edge.Tests.ps1
+++ b/tests/integration/04.Edge.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Edge" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for edge appliance deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/05.Dfw.Tests.ps1
+++ b/tests/integration/05.Dfw.Tests.ps1
@@ -17,7 +17,7 @@ Describe "DFW" {
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         write-host -ForegroundColor Green "Performing setup tasks for DFW tests"
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for edge appliance deployment"
         $script:ds = $cl | get-datastore | select -first 1
@@ -90,7 +90,7 @@ Describe "DFW" {
         $script:testvm1 = new-vm -name $testVMName1 @vmsplat
         $script:testvm2 = new-vm -name $testVMName2 @vmsplat
         $script:testvm3 = new-vm -name $testVMName3 @vmsplat
-        
+
         #Create Groupings
         $script:TestIpSet = New-NsxIpSet -Name $testIPSetName -Description "Pester dfw Test IP Set" -IpAddresses $testIPs
         $script:TestIpSet2 = New-NsxIpSet -Name $testIPSetName2 -Description "Pester dfw Test IP Set2" -IpAddresses $testIPs2
@@ -615,7 +615,7 @@ Describe "DFW" {
 
         it "Can create an l3 rule with a vnic based source" {
             # Update PowerNSX to get nics fix to arrays
-            $vm1vnic = Get-Vm $testVMName1 | Get-NetworkAdapter 
+            $vm1vnic = Get-Vm $testVMName1 | Get-NetworkAdapter
             $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -source $vm1vnic -action allow
             $rule.sources.source.type | should be "Vnic"
             $rule.destinations.destination | should be $null
@@ -813,7 +813,7 @@ Describe "DFW" {
         }
 
         it "Can create an l3 rule with a vnic based destination" {
-            $vm1vnic = Get-Vm $testVMName1 | Get-NetworkAdapter 
+            $vm1vnic = Get-Vm $testVMName1 | Get-NetworkAdapter
             $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -destination $vm1vnic -action allow
             $rule.sources.source | should be $null
             $rule.destinations.destination.type | should be "Vnic"
@@ -917,7 +917,7 @@ Describe "DFW" {
         }
 
         it "Can create an l3 rule with a vnic based applied to" {
-            $vm1vnic = Get-Vm $testVMName1 | Get-NetworkAdapter 
+            $vm1vnic = Get-Vm $testVMName1 | Get-NetworkAdapter
             $rule = $l3sec | New-NsxFirewallRule -Name "pester_dfw_rule1" -AppliedTo $vm1vnic -action allow
             $rule.sources.source | should be $null
             $rule.destinations.destination | should be $null

--- a/tests/integration/06.Nat.Tests.ps1
+++ b/tests/integration/06.Nat.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Edge NAT" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for nat edge deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/07.SslVpn.Tests.ps1
+++ b/tests/integration/07.SslVpn.Tests.ps1
@@ -31,7 +31,7 @@ Describe "sslvpn" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for sslvpn edge deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/08.Service.Tests.ps1
+++ b/tests/integration/08.Service.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Services" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
 
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix

--- a/tests/integration/09.ServiceGroups.Tests.ps1
+++ b/tests/integration/09.ServiceGroups.Tests.ps1
@@ -31,7 +31,7 @@ Describe "ServiceGroups" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
 
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix

--- a/tests/integration/10.IpSets.Tests.ps1
+++ b/tests/integration/10.IpSets.Tests.ps1
@@ -31,7 +31,7 @@ Describe "IPSets" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix
         #pester_<testabbreviation>_<objecttype><uid>.  example:

--- a/tests/integration/11.SecurityGroups.Tests.ps1
+++ b/tests/integration/11.SecurityGroups.Tests.ps1
@@ -31,7 +31,7 @@ Describe "SecurityGroups" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for edge appliance deployment"
         $script:ds = $cl | get-datastore | select -first 1

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -37,7 +37,7 @@ Describe "NSXManager" {
 
         #Test if required test SSO account exists in VC
         try {
-            $dummyconn = Connect-VIServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -NotDefault -username $TestSSOAccount -Password $TestSSOPassword -ErrorAction Stop
+            $dummyconn = Connect-VIServer $PNSXTestVC -NotDefault -username $TestSSOAccount -Password $TestSSOPassword -ErrorAction Stop
             $Global:SkipSSOTests = $false
         }
         catch {
@@ -60,7 +60,7 @@ Describe "NSXManager" {
         #Connect-NsxServer tests
         it "Can connect directly to NSX server using admin account - legacy mode" {
             $NSXManager = $DefaultNsxConnection.Server
-            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefMgrCred -VICred $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false
+            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefMgrCred -ViWarningAction "Ignore" -DefaultConnection:$false -DisableViAutoConnect
             $DirectConn | should not be $null
             $DirectConn.Version | should not be $null
             $DirectConn.BuildNumber | should not be $null
@@ -69,7 +69,7 @@ Describe "NSXManager" {
 
         it "Can connect directly to NSX server using Ent_Admin SSO account" {
             $NSXManager = $DefaultNsxConnection.Server
-            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false
+            $DirectConn = Connect-NsxServer -NsxServer $NSXManager -Credential $PNSXTestDefViCred -ViWarningAction "Ignore" -DefaultConnection:$false -DisableViAutoConnect
             $DirectConn | should not be $null
             $DirectConn.Version | should be $null
             $DirectConn.BuildNumber | should be $null

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -16,7 +16,7 @@ Describe "NSXManager" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
         $script:adminConnection = Connect-NsxServer -NsxServer $DefaultNsxConnection.Server -Credential $PNSXTestDefMgrCred -DefaultConnection:$false
 
 
@@ -37,7 +37,7 @@ Describe "NSXManager" {
 
         #Test if required test SSO account exists in VC
         try {
-            $dummyconn = Connect-VIServer $PNSXTestVC -NotDefault -username $TestSSOAccount -Password $TestSSOPassword -ErrorAction Stop
+            $dummyconn = Connect-VIServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -NotDefault -username $TestSSOAccount -Password $TestSSOPassword -ErrorAction Stop
             $Global:SkipSSOTests = $false
         }
         catch {
@@ -111,7 +111,7 @@ Describe "NSXManager" {
             #make test user auditor
             $result = Invoke-NsxRestMethod -method post -uri "/api/2.0/services/usermgmt/role/$TestSSOAccount" -body $ace.outerxml -connection $adminConnection
 
-            $testconn = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -DefaultConnection:$false
+            $testconn = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -DefaultConnection:$false
 
             $testConn | should not be $null
             $testConn.version | should not be $null

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -64,7 +64,7 @@ Describe "NSXManager" {
             $DirectConn | should not be $null
             $DirectConn.Version | should not be $null
             $DirectConn.BuildNumber | should not be $null
-            $DirectConn.ViConnection | should not be $null
+            $DirectConn.ViConnection | should be $null
         }
 
         it "Can connect directly to NSX server using Ent_Admin SSO account" {

--- a/tests/integration/12.Manager.Tests.ps1
+++ b/tests/integration/12.Manager.Tests.ps1
@@ -17,7 +17,7 @@ Describe "NSXManager" {
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
         $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
-        $script:adminConnection = Connect-NsxServer -NsxServer $DefaultNsxConnection.Server -Credential $PNSXTestDefMgrCred -DefaultConnection:$false
+        $script:adminConnection = Connect-NsxServer -NsxServer $DefaultNsxConnection.Server -Credential $PNSXTestDefMgrCred -DefaultConnection:$false -DisableViAutoConnect
 
 
         #Put any script scope variables you need to reference in your tests.

--- a/tests/integration/13.DFWGlobalOptions.Tests.ps1
+++ b/tests/integration/13.DFWGlobalOptions.Tests.ps1
@@ -31,7 +31,7 @@ Describe "DFW Global Properties" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         # Threshold Variables
         $script:cpuThreshold = "75"
         $script:cpuThreshold1 = "85"

--- a/tests/integration/14.MacSet.Tests.ps1
+++ b/tests/integration/14.MacSet.Tests.ps1
@@ -31,7 +31,7 @@ Describe "MacSets" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred
         #Put any script scope variables you need to reference in your tests.
         #For naming items that will be created in NSX, use a unique prefix
         #pester_<testabbreviation>_<objecttype><uid>.  example:

--- a/tests/integration/15.Controller.Tests.ps1
+++ b/tests/integration/15.Controller.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Controller" {
         #BeforeAll block runs _once_ at invocation regardless of number of tests/contexts/describes.
         #We load the mod and establish connection to NSX Manager here.
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefViCred -ViWarningAction "Ignore"
         $script:ctrl = Get-NsxController
         if ( @($ctrl).count -ne 1) {
             $script:SkipCtrlTest = $True

--- a/tests/integration/99.TestTemplate.ps1
+++ b/tests/integration/99.TestTemplate.ps1
@@ -31,7 +31,7 @@ Describe "Logical Thingy" {
 
         #Put any setup tasks in here that are required to perform your tests.  Typical defaults:
         import-module $pnsxmodule
-        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -Credential $PNSXTestDefMgrCred -ViWarningAction "Ignore"
+        $script:DefaultNsxConnection = Connect-NsxServer -vCenterServer $PNSXTestVC -NsxServerHint $PNSXTestNSX -Credential $PNSXTestDefMgrCred -ViWarningAction "Ignore"
         $script:cl = get-cluster | select -first 1
         write-warning "Using cluster $cl for clustery stuff"
         $script:ds = $cl | get-datastore | select -first 1


### PR DESCRIPTION
Updates to facilitate easier testing of PowerNSX 

Update Connect-NsxServer to allow override of the discovered NSX server address to aid connection from behind NAT devices.
Update tests to leverage -NsxServerHint
Update Tests to return exit code

Tested on 6.2.2 and 6.3.1 (Core and Windows)

