### PR TITLE
Removed deprecated ntp set example

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -5541,11 +5541,6 @@ function Set-NsxManager {
     such as syslog, vCenter registration and SSO configuration.
 
     .EXAMPLE
-    Set-NsxManager -NtpServer 0.pool.ntp.org -Timezone UTC
-
-    Configures NSX Manager NTP Server.
-
-    .EXAMPLE
     Set-NsxManager -SyslogServer syslog.corp.local -SyslogPort 514 -SyslogProtocol tcp
 
     Configures NSX Manager Syslog destination.
@@ -5559,7 +5554,8 @@ function Set-NsxManager {
     Set-NsxManager -vcenterusername administrator@vsphere.local -vcenterpassword VMware1! -vcenterserver vcenter.corp.local
 
     Configures the vCenter registration of NSX Manager.
-
+    .LINK
+    Set-NsxManagerTimeSettings
     #>
 
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword","")] # Unable to remove without breaking backward compatibilty.  Alternate credential parameter exists.

--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -7730,7 +7730,7 @@ function New-NsxClusterVxlanConfig {
 
     .DESCRIPTION
     VXLAN configuration of a vSphere cluster involves associating the cluster
-    with an NSX prepared VDS, and configuration of VLAN id for the atuomatically
+    with an NSX prepared VDS, and configuration of VLAN id for the automatically
     created VTEP portgroup, VTEP count and VTEP addressing.
 
     If the VDS specified is not configured for VXLAN, then an error is thrown.

--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -98,7 +98,7 @@ Function _init {
         public class InternalHttpClientHandler : HttpClientHandler {
             public InternalHttpClientHandler(bool SkipCertificateCheck) {
                 if (SkipCertificateCheck) {
-                    ServerCertificateCustomValidationCallback = delegate { return true; };
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
                 }
             }
         }


### PR DESCRIPTION
Remove set-NSXManager -ntpserver example since it does not appear to be part of function anymore.   Added help link to point to set-nsxmanagertimesettings function.