### PR TITLE
TestTemplate: Remove unused Remove-Variable

### DIFF
--- a/tests/integration/99.TestTemplate.ps1
+++ b/tests/integration/99.TestTemplate.ps1
@@ -74,6 +74,5 @@ Describe "Logical Thingy" {
         #We kill the connection to NSX Manager here.
 
         disconnect-nsxserver
-        Remove-Variable -scope global -name "conn"
     }
 }


### PR DESCRIPTION
When work on Test Suite #374 , found a issue about unused Remove Variable