### PR TITLE
Get-NsxSecurityTagAssignment changes for template objects 

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -2961,7 +2961,24 @@ Function ValidateVirtualMachine {
     $true
 }
 
-Function ValidateTagAssignment {
+Function ValidateVirtualMachineOrTemplate {
+
+        Param (
+            [Parameter (Mandatory=$true)]
+            [object]$argument
+        )
+
+        if ( -not (
+            ($argument -is [VMware.VimAutomation.ViCore.Interop.V1.Inventory.VirtualMachineInterop]) -or
+            ($argument -is [VMware.VimAutomation.ViCore.Interop.V1.Inventory.TemplateInterop])))
+        {
+            throw "Object is not a supported type.  Specify a VirtualMachine or Template object."
+        }
+
+        $true
+    }
+
+    Function ValidateTagAssignment {
 
     Param (
         [Parameter (Mandatory=$true)]
@@ -24058,8 +24075,8 @@ function Get-NsxSecurityTagAssignment {
             [ValidateScript( { ValidateSecurityTag $_ })]
             [System.Xml.XmlElement]$SecurityTag,
         [Parameter (Mandatory=$true, ValueFromPipeline=$true, ParameterSetName = "VirtualMachine")]
-            [ValidateNotNullorEmpty()]
-            [VMware.VimAutomation.ViCore.Interop.V1.Inventory.VirtualMachineInterop]$VirtualMachine,
+            [ValidateScript( { ValidateVirtualMachineOrTemplate $_ })]
+            [object[]]$VirtualMachine,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -24082,8 +24099,24 @@ function Get-NsxSecurityTagAssignment {
 
                     foreach ($node in $nodes) {
 
-                        #Get the VI VM object...
-                        $vm = Get-Vm -Server $Connection.VIConnection -id "VirtualMachine-$($node.objectId)"
+                        # Get the VI VM object...
+                        # But seems that NSX allows you to apply a security tag to a VM Template.
+                        # So if a tag has been applied to a template we need to look for
+                        # it via Get-VM and also Get-Template.
+                        # If after trying both commands it still can't find the VM object, I'm
+                        # buggered if I know where to look for it. Considering it exists somewhere
+                        # because its being returned as a valid object via the NSX API.
+                        try {
+                            $vm = Get-Vm -Server $Connection.VIConnection -id "VirtualMachine-$($node.objectId)" -ErrorAction stop
+                        }
+                        catch {
+                            try {
+                                $vm = Get-Template -Server $Connection.VIConnection -id "VirtualMachine-$($node.objectId)" -ErrorAction stop
+                            }
+                            catch {
+                                throw "Could not find object with MoRef $($node.objectId) using Get-VM or Get-Template."
+                            }
+                        }
                         [pscustomobject]@{
                             "SecurityTag" = $SecurityTag;
                             "VirtualMachine" = $vm

--- a/tests/integration/11.SecurityGroups.Tests.ps1
+++ b/tests/integration/11.SecurityGroups.Tests.ps1
@@ -1450,7 +1450,7 @@ Describe "SecurityGroups" {
             $assignment = Get-Template $testtemplate1 | Get-NsxSecurityTagAssignment
             $assignment | should not be $null
             ($assignment | measure).count | should be 1
-            $assignment.VirtualMachine.name | should be $testtemplate1
+            $assignment.VirtualMachine.name | should be $testTemplateName
         }
     }
 }

--- a/tests/integration/11.SecurityGroups.Tests.ps1
+++ b/tests/integration/11.SecurityGroups.Tests.ps1
@@ -1401,4 +1401,56 @@ Describe "SecurityGroups" {
         it "Can retrieve local Security Group SecurityGroup applicable members specifying scopeid of an edge" {
         }
     }
+
+    Context "Security Tag Assignments" {
+        BeforeAll {
+            $testTemplateName = "Pester_sg_template_1"
+            $testtemplate1 = New-Template -VM $testvm1 -Name $testTemplateName -Datastore $ds -Location $folder
+        }
+
+        AfterAll {
+            Get-Template | ? {$_.name -match "^pester"} | Remove-Template -confirm:$false
+        }
+
+        BeforeEach {
+            $testTagName = "pester_tag_1"
+            $testTag = New-NsxSecurityTag -Name $testTagName
+        }
+
+        AfterEach {
+            Get-NsxSecurityTag | Where-Object {$_.name -match "^pester"} | Remove-NsxSecurityTag -confirm:$false
+        }
+
+        it "Can get security tag assignment from a Security Tag" {
+            Get-VM $testVMName1 | New-NsxSecurityTagAssignment -ApplyTag $testTag
+            $assignment = $testTag | Get-NsxSecurityTagAssignment
+            $assignment | should not be $null
+            ($assignment | measure).count | should be 1
+            $assignment.VirtualMachine.name | should be $testVMName1
+        }
+
+        it "Can get security tag assignment from a Virtual Machine" {
+            Get-VM $testVMName1 | New-NsxSecurityTagAssignment -ApplyTag $testTag
+            $assignment = Get-VM $testVMName1 | Get-NsxSecurityTagAssignment
+            $assignment | should not be $null
+            ($assignment | measure).count | should be 1
+            $assignment.VirtualMachine.name | should be $testVMName1
+        }
+        it "Can get security tag assignment from a Template" {
+            # Now PowerNSX doesn't allow you to actually apply a security tag to
+            # a virtual machine template. But if a virtual machine was converted
+            # to a template and it had a tag already applied to it, then it may
+            # be returned when looking up tag assignments.
+
+            # Lets apply a tag manually to a template
+            $URI = "/api/2.0/services/securitytags/tag/$($testTag.objectid)/vm/$($testtemplate1.ExtensionData.MoRef.value)"
+            $response = invoke-nsxwebrequest -method "put" -uri $URI -connection $connection
+            $response.StatusCode | should be 200
+
+            $assignment = Get-Template $testtemplate1 | Get-NsxSecurityTagAssignment
+            $assignment | should not be $null
+            ($assignment | measure).count | should be 1
+            $assignment.VirtualMachine.name | should be $testtemplate1
+        }
+    }
 }


### PR DESCRIPTION
fixed get-nsxsecuritytagassignment when a moref references a template rather than a vm.

Fixes #279