### PR TITLE
Display warning for -RuleType param when passing a section along pipeline

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -26872,7 +26872,11 @@ function Get-NsxFirewallRule {
 
     )
 
-    begin {}
+    begin {
+        if ( ( $PSCmdlet.ParameterSetName -eq "Section" ) -and $PSBoundParameters.ContainsKey('RuleType') ){
+            write-warning "The -RuleType parameter is no longer required (and will be ignored) when passing a section along the pipeline. This will be deprecated and removed in a future release."
+        }
+    }
 
     process {
 


### PR DESCRIPTION
Main fix was introduced in #387 - Commit 70c9133
Addresses #249 