### PR TITLE
Make Get-NsxSecurityTagAssignment faster for VMs

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -24670,8 +24670,8 @@ function Get-NsxSecurityTagAssignment {
             [ValidateScript( { ValidateSecurityTag $_ })]
             [System.Xml.XmlElement]$SecurityTag,
         [Parameter (Mandatory=$true, ValueFromPipeline=$true, ParameterSetName = "VirtualMachine")]
-            [ValidateScript( { ValidateVirtualMachineOrTemplate $_ })]
-            [object[]]$VirtualMachine,
+            [ValidateNotNullorEmpty()]
+            [VMware.VimAutomation.ViCore.Interop.V1.Inventory.VirtualMachineInterop[]]$VirtualMachine,
         [Parameter (Mandatory=$False)]
             #PowerNSX Connection object
             [ValidateNotNullOrEmpty()]
@@ -24722,11 +24722,26 @@ function Get-NsxSecurityTagAssignment {
 
             'VirtualMachine' {
 
-                #I know this is inneficient, but attempt at refactoring has led down a rabbit hole I dont have time for at the moment.
-                # 'Ill be back...''
-                $vmMoid = $VirtualMachine.ExtensionData.MoRef.Value
-                Write-Progress -activity "Fetching Security Tags assigned to Virtual Machine $($vmMoid)"
-                Get-NsxSecurityTag -connection $connection | Get-NsxSecurityTagAssignment -connection $connection | Where-Object {($_.VirtualMachine.id -replace "VirtualMachine-","") -eq $($vmMoid)}
+                $SecurityTags = Get-NSXSecurityTag -connection $connection
+                $count = 0
+                foreach ($SecurityTag in $SecurityTags) {
+                    $count++
+                    Write-Progress -Activity "Checking All Security Tags for Virtual Machine Assignments" -Status "Progress->" -PercentComplete ($count/$SecurityTags.Count*100)
+                    $URI = "/api/2.0/services/securitytags/tag/$($SecurityTag.objectId)/vm"
+                    [System.Xml.XmlDocument]$response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+                    if ( (Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $response -Query 'descendant::basicinfolist/basicinfo') ) {
+                        $nodes = (Invoke-XPathQuery -QueryMethod SelectNodes -Node $response -Query 'descendant::basicinfolist/basicinfo')
+                        foreach ($vm in $VirtualMachine) {
+                            $vmMoid = $vm.ExtensionData.MoRef.Value
+                            if ($vmMoid -In $nodes.objectId) {
+                                [pscustomobject]@{
+                                    "SecurityTag" = $SecurityTag;
+                                    "VirtualMachine" = $vm
+                                }
+                            }
+                        }                    
+                    }
+                }	
             }
         }
     }


### PR DESCRIPTION
The current implementation for VirtualMachines in the Get-NsxSecurityTagAssignment function is very slow in my environment to the point of being unusable.

With this commit, I went from letting `Get-VM testvm | Get-NSXSecurityTagAssignment` run for over 30 minutes with no result to it returning in 1 minute and 40 seconds.

Also, something like`,@(Get-VM vm1,vm2) | Get-NSXSecurityTagAssignment` or `Get-NSXSecurityTagAssignment -VirtualMachine (Get-VM "vm1,"vm2")` will be much faster as it will only need to make the API calls to each Security Tag once.