### PR TITLE
Minor fix for new-nsxmanager to support nsx 6.4.0

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -5942,7 +5942,11 @@ function New-NsxManager{
         $OvfConfiguration = Get-OvfConfiguration -Ovf $NsxManagerOVF
 
         #Network Mapping to portgroup need to be defined.
-        $OvfConfiguration.NetworkMapping.VSMgmt.Value = $ManagementPortGroupName
+        #6.4.0 GA changed the name of the network that is mapped, so now we need to 
+        #determine what it is rather than assume it is vsmgmt
+        $networkobj = get-member -membertype CodeProperty -inputobject $OvfConfiguration.NetworkMapping
+        $networkname = $networkobject.name
+        $OvfConfiguration.NetworkMapping.$networkname.Value = $ManagementPortGroupName
 
         # OVF Configuration values.
         $OvfConfiguration.common.vsm_cli_passwd_0.value    = $CliPassword


### PR DESCRIPTION
NSX manager ova has a different network mapping name that breaks new-nsxmanager.  Minor fix to add some logic to determine the ova network name to be mapped.