### PR TITLE
Convert2entitybelongsto

### DIFF
--- a/Examples/Convert2EntityBelongsTo.ps1
+++ b/Examples/Convert2EntityBelongsTo.ps1
@@ -67,10 +67,10 @@ param (
 ################################################################################
 
 if ($CreateTestEnvironment) {
-    1..9 | % {New-NsxSecurityTag -Name EntityTagTest_00$_ | out-null}
-    $st = Get-NsxSecurityTag | ? {$_.name -match "EntityTagTest"}
+    1..9 | ForEach-Object {New-NsxSecurityTag -Name EntityTagTest_00$_ | out-null}
+    $st = Get-NsxSecurityTag | Where-Object {$_.name -match "EntityTagTest"}
     $criteria0 = New-NsxDynamicCriteriaSpec -Key SecurityTag -Value dummyNonExistentTag -Condition equals
-    0..8 | % { New-Variable -Name criteria$($_ + 1) -value (New-NsxDynamicCriteriaSpec -Key SecurityTag -Value ($st[$_].name) -Condition equals)}
+    0..8 | ForEach-Object { New-Variable -Name criteria$($_ + 1) -value (New-NsxDynamicCriteriaSpec -Key SecurityTag -Value ($st[$_].name) -Condition equals)}
     $group1 = New-NsxSecurityGroup -Name EntityTestGroup_001
     $group2 = New-NsxSecurityGroup -Name EntityTestGroup_002
     $group3 = New-NsxSecurityGroup -Name EntityTestGroup_003
@@ -85,8 +85,8 @@ if ($CreateTestEnvironment) {
 }
 
 if ($TrashTestEnvironment) {
-    Get-NsxSecurityGroup | ? {$_.name -match "EntityTestGroup_"} | Remove-NsxSecurityGroup -confirm:$False
-    Get-NsxSecurityTag | ? {$_.name -match "EntityTagTest"} | Remove-NsxSecurityTag -confirm:$False
+    Get-NsxSecurityGroup | Where-Object {$_.name -match "EntityTestGroup_"} | Remove-NsxSecurityGroup -confirm:$False
+    Get-NsxSecurityTag | Where-Object {$_.name -match "EntityTagTest"} | Remove-NsxSecurityTag -confirm:$False
     exit
 }
 
@@ -210,7 +210,7 @@ if ($output) {
             # Now we've found some, lets swap them to use entity belong to
             foreach ($dynamicCriteriaIdentified in $sgQueryOutput) {
                 # Identify if this is the only criteria defined in the set?
-                $dynamicCriteriaInSetCount = (($dynamicCriteriaIdentified.parentNode).dynamicCriteria | measure).count
+                $dynamicCriteriaInSetCount = (($dynamicCriteriaIdentified.parentNode).dynamicCriteria | Measure-Object).count
                 write-log -level verbose -msg "Criteria set : Criteria count = $($dynamicCriteriaInSetCount)"
 
                 # Lookup the corresponding tag objectid

--- a/Examples/Convert2EntityBelongsTo.ps1
+++ b/Examples/Convert2EntityBelongsTo.ps1
@@ -173,8 +173,8 @@ $securityGroupsAffected = @{}
 
 if ($output) {
     $foundInstances = ($output| Measure-Object).count
-    write-log -level host -msg "Instances where 'Security Tag' & 'equals' is configured : $($foundInstances) " -ForegroundColor green
-    write-log -level host -msg "Adding Security Group names to logfile. "
+    write-log -level host -msg "Instances where 'Security Tag' & 'equals' is configured : $($foundInstances)" -ForegroundColor green
+    write-log -level host -msg "Adding Security Group names to logfile."
 
     # Go through each criteria which matches the query and add the security group
     # to the hashtable of affected security groups

--- a/Examples/Convert2EntityBelongsTo.ps1
+++ b/Examples/Convert2EntityBelongsTo.ps1
@@ -1,0 +1,142 @@
+## PowerNSX Sample Script
+## Author: Dale Coghlan
+## version 1.0
+## Jan 2018
+
+########################################
+# 1 - Connect to your NSX Manager
+# 2 - Run the script and it will report how many dynamic criteria are eligible
+#     to convert to entity_belongs_to
+#       ./Convert2EntityBelongsTo.ps1
+# 3 - If your happy with what it wants to change, run the script with the 
+#     -DoTheNeedful parameter
+#       ./Convert2EntityBelongsTo.ps1 -DoTheNeedful
+# 4 - Sit back, have a drink, and reflect on what you just did and how long it
+#     would have taken you to do manually.
+
+
+<#
+Copyright © 2018 VMware, Inc. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License version 2, as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTIBILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License version 2 for more details.
+
+You should have received a copy of the General Public License version 2 along with this program.
+If not, see https://www.gnu.org/licenses/gpl-2.0.html.
+
+The full text of the General Public License 2.0 is provided in the COPYING file.
+Some files may be comprised of various open source software components, each of which
+has its own license that is located in the source code of the respective component.
+#>
+
+
+<#
+Often when NSX Security Groups are configured and some dynamic criteria rules
+are created, it has been observed that security tag "equals" is often
+configured. This is not an optimal configuration, and should be converted to use
+entity_belongs_to. This script will automate the process.
+is configured
+
+It is intended to be an example of how to perform a certain action and may not
+be suitable for all purposes.  Please read an understand its action and modify
+as appropriate, or ensure its suitability for a given situation before blindly
+running it.
+
+Testing is limited to a lab environment.  Please test accordingly.
+
+#>
+
+param (
+
+    [Parameter (Mandatory=$False)]
+        #Set this switch to modify the NSX Configuration. By default will only report what will change
+        [switch]$DoTheNeedful=$false
+)
+
+# Make sure we have a connection to NSX Manager
+If ( -not $DefaultNsxConnection ) {
+    throw "Please connect to to NSX first"
+}
+
+$secGrpCacheLocal = Get-NsxSecurityGroup -LocalOnly
+$secTagCache = Get-NsxApplicableMember -SecurityGroupApplicableMembers -MemberType SecurityTag
+
+# Here we clone the xml response so that we have a copy of the xml that we can
+# modify and use to send back to the NSX Manager with the rules removed from it
+$modifiedxml = $secGrpCacheLocal.CloneNode($true)
+
+$modifiedxml.gettype()
+foreach ($blah in $secGrpCacheLocal) {
+    if ( $modifiedxml -is [System.Xml.XmlElement] ) {
+        write-host "it is an element"
+        $SecurityGroupId = $securityGroup.objectId
+        $_SecurityGroup = $SecurityGroup.cloneNode($true)
+    } else {
+        write-host "not so"
+    }
+}
+exit
+
+
+[System.Xml.XmlElement]$xmltest = ($secGrpCacheLocal | format-xml)
+$query = "//*dynamiccriteria[key='VM.SECURITY_TAG' and criteria='equals']"
+$output = Invoke-XpathQuery -QueryMethod SelectNodes -Node $xmltest -query "//*dynamiccriteria[key='VM.SECURITY_TAG' and criteria='equals']"
+
+$output
+
+exit
+# Supply the path to the file containing the list of rule IDs that are required
+# to be deleted. The script expects a the file contain a single rule ID per line
+$file = $args[0]
+
+# Test to make sure the file path provided actually exists
+if (-Not (Test-Path -Path $file) ) {
+    throw "The file containing the rules to delete does not exist"
+}
+
+$f = Get-Content -Path $file
+
+
+
+# Go and grab the current firewall configuration
+$URI = "/api/4.0/firewall/globalroot-0/config"
+$response = invoke-nsxrestmethod -method "get" -uri $URI
+
+# Here we clone the xml response so that we have a copy of the xml that we can
+# modify and use to send back to the NSX Manager with the rules removed from it
+$modifiedxml = $response.CloneNode($true)
+
+$generationNumber = $modifiedxml.firewallConfiguration.generationNumber
+$modified = $false
+
+# Lets loop through the rule ids in the file and find them in the XML. If we
+# find them, we remove the node and set the modified flag to $true
+foreach ($id in $f ) {
+    $node = Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $modifiedxml -Query "firewallConfiguration/*/section/rule[@id=`"$id`"]"
+    if ($node) {
+        $node.parentnode.removechild($node) | out-null
+        $modified = $true
+    }
+}
+
+# If we managed to remove some xml then lets go ahead and save the original xml
+# and the modified xml, just so we can see whats changed. We could have just
+# saved the individual nodes that were being removed, but this does not give you
+# the context of where abouts in the rule base the rules were located.
+if ($modified) {
+    if (! (Test-Path -Path "$generationNumber-original.xml")) {
+        $response.firewallconfiguration | Export-NsxObject -FilePath "$generationNumber-original.xml"
+    }
+
+    if (! (Test-Path -Path "$generationNumber-modified.xml")) {
+        $modifiedxml.firewallconfiguration | Export-NsxObject -FilePath "$generationNumber-modified.xml"
+    }
+
+    $IfMatchHeader = @{"If-Match"=$generationNumber}
+    invoke-nsxwebrequest -method "put" -uri $URI -body $modifiedxml.outerXml -extraheader $IfMatchHeader | out-null
+}
+

--- a/Examples/Convert2EntityBelongsTo.ps1
+++ b/Examples/Convert2EntityBelongsTo.ps1
@@ -210,7 +210,7 @@ if ($output) {
             # Now we've found some, lets swap them to use entity belong to
             foreach ($dynamicCriteriaIdentified in $sgQueryOutput) {
                 # Identify if this is the only criteria defined in the set?
-                $dynamicCriteriaInSetCount = (($dynamicCriteriaIdentified.parentNode).dynamicCriteria).count
+                $dynamicCriteriaInSetCount = (($dynamicCriteriaIdentified.parentNode).dynamicCriteria | measure).count
                 write-log -level verbose -msg "Criteria set : Criteria count = $($dynamicCriteriaInSetCount)"
 
                 # Lookup the corresponding tag objectid

--- a/Examples/Convert2EntityBelongsTo.ps1
+++ b/Examples/Convert2EntityBelongsTo.ps1
@@ -5,8 +5,9 @@
 
 ########################################
 # 1 - Connect to your NSX Manager
-# 2 - Run the script and it will log the security groups which have dynamic
-#     criteria that are configured with security tag equals
+# 2 - Run the script and it will find the security groups which have dynamic
+#     criteria that are configured with "security tag" & "equals" and add them
+#     to the log file
 #       ./Convert2EntityBelongsTo.ps1
 # 3 - If your happy with what it wants to change, run the script with the
 #     -DoTheNeedful parameter
@@ -39,6 +40,19 @@ are created, it has been observed that security tag "equals" is often
 configured. This is not an optimal configuration, and should be converted to use
 entity_belongs_to. This script will automate the process.
 
+If there is only a single dynamic criteria identified in the criteria set, that
+is configured with "Security Tag" & "Equals to", the script will remove the
+dynamic criteria/set and add the security tag directly as a statically included
+member of the security group.
+
+If there are multiple criteria in a criteria set where it find at least 1 of
+them is configured with "Security Tag" & "Equals to", the script will do an
+in-place conversion to "Entity" & "Belongs to".
+
+If there is no corresponding security tag found that matches what is in the
+dynamic criteria, then the script will leave it alone, but a message will be
+displayed on the screen as well as captured in the logfile.
+
 It is intended to be an example of how to perform a certain action and may not
 be suitable for all purposes. Please read an understand its action and modify
 as appropriate, or ensure its suitability for a given situation before blindly
@@ -48,15 +62,18 @@ Testing is limited to a lab environment.  Please test accordingly.
 
 #>
 
+[CmdletBinding(DefaultParameterSetName="StandardExecution")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments","")]
+
 param (
 
-    [Parameter (Mandatory=$False)]
+    [Parameter (Mandatory=$False, ParameterSetName="StandardExecution")]
         #Set this switch to modify the NSX Configuration. By default will only report what will change
         [switch]$DoTheNeedful=$false,
-    [Parameter (Mandatory=$False)]
+    [Parameter (Mandatory=$False, ParameterSetName="CreateTestEnvironment")]
         # Used to setup a small test set of tags and groups
         [switch]$CreateTestEnvironment=$false,
-    [Parameter (Mandatory=$False)]
+    [Parameter (Mandatory=$False, ParameterSetName="TrashTestEnvironment")]
         # Used to trash the test tags and groups
         [switch]$TrashTestEnvironment=$false
 

--- a/Examples/Convert2EntityBelongsTo.ps1
+++ b/Examples/Convert2EntityBelongsTo.ps1
@@ -53,7 +53,17 @@ If there is no corresponding security tag found that matches what is in the
 dynamic criteria, then the script will leave it alone, but a message will be
 displayed on the screen as well as captured in the logfile.
 
-It is intended to be an example of how to perform a certain action and may not
+A couple of parameter switches have been included to create some sample NSX
+Security Tags and NSX Security Groups with dynamic criteria specified so that
+you can use these to see how the script functions.
+
+./Convert2EntityBelongsTo.ps1 -TrashTestEnvironment -CreateTestEnvironment
+
+The above will cleanup any previous test tags and groups, and then create them
+again. You can use these parameter switches independantly of each other if you
+so desire.
+
+This is intended to be an example of how to perform a certain action and may not
 be suitable for all purposes. Please read an understand its action and modify
 as appropriate, or ensure its suitability for a given situation before blindly
 running it.
@@ -70,10 +80,10 @@ param (
     [Parameter (Mandatory=$False, ParameterSetName="StandardExecution")]
         #Set this switch to modify the NSX Configuration. By default will only report what will change
         [switch]$DoTheNeedful=$false,
-    [Parameter (Mandatory=$False, ParameterSetName="CreateTestEnvironment")]
+    [Parameter (Mandatory=$False, ParameterSetName="TestLab")]
         # Used to setup a small test set of tags and groups
         [switch]$CreateTestEnvironment=$false,
-    [Parameter (Mandatory=$False, ParameterSetName="TrashTestEnvironment")]
+    [Parameter (Mandatory=$False, ParameterSetName="TestLab")]
         # Used to trash the test tags and groups
         [switch]$TrashTestEnvironment=$false
 
@@ -82,28 +92,32 @@ param (
 ################################################################################
 # Setup and Teardown some test groups if required
 ################################################################################
+if ( $PSCmdlet.ParameterSetName -eq "TestLab") {
 
-if ($CreateTestEnvironment) {
-    1..9 | ForEach-Object {New-NsxSecurityTag -Name EntityTagTest_00$_ | out-null}
-    $st = Get-NsxSecurityTag | Where-Object {$_.name -match "EntityTagTest"}
-    $criteria0 = New-NsxDynamicCriteriaSpec -Key SecurityTag -Value dummyNonExistentTag -Condition equals
-    0..8 | ForEach-Object { New-Variable -Name criteria$($_ + 1) -value (New-NsxDynamicCriteriaSpec -Key SecurityTag -Value ($st[$_].name) -Condition equals)}
-    $group1 = New-NsxSecurityGroup -Name EntityTestGroup_001
-    $group2 = New-NsxSecurityGroup -Name EntityTestGroup_002
-    $group3 = New-NsxSecurityGroup -Name EntityTestGroup_003
-    $group4 = New-NsxSecurityGroup -Name EntityTestGroup_004
+    if ($TrashTestEnvironment) {
+        Get-NsxSecurityGroup | Where-Object {$_.name -match "EntityTestGroup_"} | Remove-NsxSecurityGroup -confirm:$False
+        Get-NsxSecurityTag | Where-Object {$_.name -match "EntityTagTest"} | Remove-NsxSecurityTag -confirm:$False
+    }
 
-    Get-NsxSecurityGroup -objectId $group1.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria1,$criteria2
-    Get-NsxSecurityGroup -objectId $group1.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria3,$criteria0,$criteria4
-    Get-NsxSecurityGroup -objectId $group2.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria3,$criteria5
-    Get-NsxSecurityGroup -objectId $group3.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria6,$criteria7,$criteria8,$criteria9
-    Get-NsxSecurityGroup -objectId $group4.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria5
-    exit
-}
+    if ($CreateTestEnvironment) {
+        1..9 | ForEach-Object {New-NsxSecurityTag -Name EntityTagTest_00$_ | out-null}
+        $st = Get-NsxSecurityTag | Where-Object {$_.name -match "EntityTagTest"}
 
-if ($TrashTestEnvironment) {
-    Get-NsxSecurityGroup | Where-Object {$_.name -match "EntityTestGroup_"} | Remove-NsxSecurityGroup -confirm:$False
-    Get-NsxSecurityTag | Where-Object {$_.name -match "EntityTagTest"} | Remove-NsxSecurityTag -confirm:$False
+        $criteria0 = New-NsxDynamicCriteriaSpec -Key SecurityTag -Value dummyNonExistentTag -Condition equals
+        0..8 | ForEach-Object { New-Variable -Name criteria$($_ + 1) -value (New-NsxDynamicCriteriaSpec -Key SecurityTag -Value ($st[$_].name) -Condition equals)}
+
+        $group1 = New-NsxSecurityGroup -Name EntityTestGroup_001
+        $group2 = New-NsxSecurityGroup -Name EntityTestGroup_002
+        $group3 = New-NsxSecurityGroup -Name EntityTestGroup_003
+        $group4 = New-NsxSecurityGroup -Name EntityTestGroup_004
+
+        Get-NsxSecurityGroup -objectId $group1.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria1,$criteria2
+        Get-NsxSecurityGroup -objectId $group1.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria3,$criteria0,$criteria4
+        Get-NsxSecurityGroup -objectId $group2.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria3,$criteria5
+        Get-NsxSecurityGroup -objectId $group3.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria6,$criteria7,$criteria8,$criteria9
+        Get-NsxSecurityGroup -objectId $group4.objectid | Add-NsxDynamicMemberSet -SetOperator OR -CriteriaOperator ALL -DynamicCriteriaSpec $criteria5
+    }
+
     exit
 }
 


### PR DESCRIPTION
Added an example script that can be used to find NSX Security Group dynamic criteria where they have been configured as "Security Tag" & "Equals to", and change them to either be statically included members, or convert them to "Entity" & "Belongs to"