### PR TITLE
Initial changes to module support powershell core

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -73,7 +73,7 @@ Function _init {
         $script:PNsxPSTarget = "Desktop"
     }
 
-    if ( $script:PNsxPSTarget -eq "Core" ) {
+    if ( ( $script:PNsxPSTarget -eq "Core" ) -and ( $PSVersionTable.GitCommitId -notmatch '^v6.[\d].[\d]+$') ) {
 
         if ( $PSVersionTable.GitCommitId -ne 'v6.0.0-alpha.18') {
             write-warning "This build of PowerShell core has known issues that affect PowerNSX.  The only recommended build of PowerShell Core at this stage is alpha-18."
@@ -205,7 +205,7 @@ function Invoke-XpathQuery {
 
     )
 
-    If ( $script:PNsxPSTarget -eq "Core") {
+    If ( ( $script:PNsxPSTarget -eq "Core") -and ($PSVersionTable.GitCommitId -eq "v6.0.0-alpha.18") ) {
         #Use the XPath extensions class to perform the query
         switch ($QueryMethod) {
             "SelectSingleNode" {


### PR DESCRIPTION
- Added version check to pass if a GA release is found.
- Still enforces v6.0.0-alpha.18 if user hasn't upgraded to Powershell Core GA
- Modified Invoke-XpathQuery as the change to .Net Core 2.0.x removed support SelectSingleNode/SelectNodes from System.Xml.XmlDocumentXPathExtensions. Instead they are now handled in the standard System.Xml.XmlDocument namespace.