### PR TITLE
Fix examples about NsxEdgeRouting(-StaticRoute)

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -17055,9 +17055,9 @@ function Get-NsxEdgeRouting {
     the specified Edge Services Gateway.
 
     .EXAMPLE
-    Get routing configuration for the ESG Edge01
+    Get-NsxEdge Edge01 | Get-NsxEdgeRouting
 
-    PS C:\> Get-NsxEdge Edge01 | Get-NsxEdgeRouting
+    Get routing configuration for the ESG Edge01
 
     #>
 
@@ -17108,9 +17108,9 @@ function Get-NsxEdgeStaticRoute {
     routing configuration specified.
 
     .EXAMPLE
-    Get static routes defining on ESG Edge01
+    Get-NsxEdge 01 | Get-NsxEdgeRouting | Get-NsxEdgeStaticRoute
 
-    PS C:\> Get-NsxEdge | Get-NsxEdgeRouting | Get-NsxEdgeStaticRoute
+    Get static routes defining on ESG Edge01
 
     #>
 


### PR DESCRIPTION
Need to set cmdlet before text
and also only get static route of Edge01