### PR TITLE
Finish #541 - return behavior to one-object per assignment, keep speed

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -24737,9 +24737,9 @@ function Get-NsxSecurityTagAssignment {
                     [System.Xml.XmlDocument]$oRestResponse = Invoke-NsxRestMethod -Method "GET" -Uri $URI -Connection $connection
                     ## for each SecurityTag object in .securityTags property of the response (if any), return a new object with SecurityTag and VirtualMachine properties (in the same way that the by-Tag parameterset behaves)
                     if (-not [System.String]::IsNullOrEmpty($oRestResponse.securityTags)) {
-                        $oRestResponse.securityTags | Foreach-Object {
+                        $oRestResponse.securityTags.securityTag | Foreach-Object {
                             [pscustomobject]@{
-                                "SecurityTag" = $_.securityTag
+                                "SecurityTag" = $_
                                 "VirtualMachine" = $oThisVM
                             } ## end new-object
                         } ## end new-object


### PR DESCRIPTION
This update fixes the situation I described at https://github.com/vmware/powernsx/issues/541#issuecomment-414466996.  It does so by:
- iterating over the `.securityTag` subproperty which is a single property with a value that can be an array (previously it was thought that there were multiple values with a `.securityTag` property in the parent `$oRestResponse.securityTags` property -- this was incorrect)

And, this update also adds/updates the tests:
- now tests for not just presence of returned tag assignment objects, but that the count thereof corresponds to the known number of assignments (to try to prevent re-occurrence of this problem that I previously created and have now fixed)

Let me know how things look.