### PR TITLE
Fixing bug in New-NsxLoadBalancerApplicationRule

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -32183,7 +32183,7 @@ function New-NsxLoadBalancerApplicationRule {
         #Store the edgeId and remove it from the XML as we need to post it...
         $edgeId = $LoadBalancer.edgeId
 
-        if ( -not $_LoadBalancer.enabled -eq 'true' ) {
+        if ( -not $LoadBalancer.enabled -eq 'true' ) {
             write-warning "Load Balancer feature is not enabled on edge $($edgeId).  Use Set-NsxLoadBalancer -EnableLoadBalancing to enable."
         }
         #Create a new XML document. Use applicationRule as root.

--- a/tests/integration/20.LB.Tests.ps1
+++ b/tests/integration/20.LB.Tests.ps1
@@ -304,6 +304,20 @@ Describe "Edge Load Balancer" {
 
     }
 
+    Context "Load Balancer App Rule" {
+
+        it "Add LB App Rule" {
+            Get-NsxEdge -Name $lbedge1name | Get-NsxLoadBalancer | New-NsxLoadBalancerApplicationRule -Name "lb_app_rule" -Script "timeout client 100s"
+
+            $lb_app_rule = Get-NsxEdge -Name $lbedge1name | Get-NsxLoadBalancer | Get-NsxLoadBalancerApplicationRule -Name "lb_app_rule"
+            $lb_app_rule.name | should be "lb_app_rule"
+            $lb_app_rule.script | should be "timeout client 100s"
+
+            # There's no PowerNSX cmdlet to remove an application rule. Will be cleaned up as a result of deleting the Edge.
+        }
+
+    }
+    
     AfterAll {
         #AfterAll block runs _once_ at completion of invocation regardless of number of tests/contexts/describes.
         #Clean up anything you create in here.  Be forceful - you want to leave the test env as you found it as much as is possible.


### PR DESCRIPTION
Fixing bug in New-NsxLoadBalancerApplicationRule and adding corresponding LB test "Load Balancer App Rule".

This is the error returned by the New-NsxLoadBalancerApplicationRule when creating a LB application rule:
```
RuntimeException: The variable '$_LoadBalancer' cannot be retrieved because it has not been set.
        at New-NsxLoadBalancerApplicationRule<Process>, PowerNSX.psm1: line 32186
        at Get-NsxLoadBalancer<Process>, PowerNSX.psm1: line 30094
        at Get-NsxEdge, PowerNSX.psm1: line 13527
```
		
It looks like a typo, since the parameter passed to the function doesn't have the "_" in front of it.

I have added "Load Balancer App Rule" which reproduces the error and then demonstrates that this change fixes the issue.