### PR TITLE
Fixing bug in New-NsxLoadBalancerPool

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -31089,8 +31089,9 @@ function New-NsxLoadBalancerPool {
             write-warning "Load Balancer feature is not enabled on edge $($edgeId). Use Set-NsxLoadBalancer -Enabled to enable."
         }
 
-        [System.XML.XMLElement]$xmlPool = $_LoadBalancer.OwnerDocument.CreateElement("pool")
-        $_LoadBalancer.appendChild($xmlPool) | out-null
+        [System.XML.XmlDocument]$xmldoc = New-Object System.XML.XmlDocument
+        [System.XML.XMLElement]$xmlPool = $xmldoc.CreateElement("pool")  
+        $xmldoc.appendChild($xmlPool) | out-null
 
         Add-XmlElement -xmlRoot $xmlPool -xmlElementName "name" -xmlElementText $Name
         Add-XmlElement -xmlRoot $xmlPool -xmlElementName "description" -xmlElementText $Description
@@ -31108,11 +31109,11 @@ function New-NsxLoadBalancerPool {
             }
         }
 
-        $URI = "/api/4.0/edges/$EdgeId/loadbalancer/config"
-        $body = $_LoadBalancer.OuterXml
+        $URI = "/api/4.0/edges/$EdgeId/loadbalancer/config/pools"
+        $body = $xmlPool.OuterXml
 
         Write-Progress -activity "Update Edge Services Gateway $($EdgeId)" -status "Load Balancer Config"
-        $null = invoke-nsxwebrequest -method "put" -uri $URI -body $body -connection $connection
+        $null = invoke-nsxwebrequest -method "post" -uri $URI -body $body -connection $connection
         write-progress -activity "Update Edge Services Gateway $($EdgeId)" -completed
 
         $UpdatedEdge = Get-NsxEdge -objectId $($EdgeId) -connection $connection


### PR DESCRIPTION
Fixing a bug in New-NsxLoadBalancerPool, where it fails to create a new pool on the Edge, when Edge already has one existing pool and one existing VIP.

This is the error message you get:
```
WebException: The remote server returned an error: (500) Internal Server Error.
        InternalNsxApiException: Invoke-NsxWebRequest : The NSX API response received indicates a failure. 500 : Internal Server Error : Response Body: {"errorCode":100,"details":null,"rootCauseString":null,"moduleName":null,"errorData":null}
        at Invoke-NsxWebRequest, PowerNSX.psm1: line 4354
        at New-NsxLoadBalancerPool<Process>, PowerNSX.psm1: line 31115
        at Get-NsxLoadBalancer<Process>, PowerNSX.psm1: line 30094
        at Get-NsxEdge, PowerNSX.psm1: line 13527
```

All credit goes to @neoxinth who fixed this in pull request #435. I just added a Pester test for this bug for regression testing purposes.

There is a full explanation of why this issue happens in the first place, which you can find in the discussion thread for #435.