### PR TITLE
Add pagination support

### DIFF
--- a/module/PowerNSX.psm1
+++ b/module/PowerNSX.psm1
@@ -25146,11 +25146,50 @@ function Get-NsxSecurityTag {
             #either all or by name
             $URI = "/api/2.0/services/securitytags/tag"
             [System.Xml.XmlDocument]$response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+
+            $securityTags = @()
+
+            if ($response.securityTags | Get-Member -memberType Properties -Name pagingInfo) {
+                $defaultPageSize = 1024
+                $itemIndex =  0
+                $startingIndex = 0
+                $pagingInfo = $response.securityTags.pagingInfo
+                if ( [int]$paginginfo.totalCount -ne 0 ) {
+                    Write-Debug "$($MyInvocation.MyCommand.Name) : SecurityTag count non zero"
+                    do {
+                        Write-Debug "$($MyInvocation.MyCommand.Name) : In paging loop. PageSize: $($pagingInfo.PageSize), StartIndex: $($paginginfo.startIndex), TotalCount: $($paginginfo.totalcount)"
+
+                        while (($itemindex -lt ([int]$paginginfo.pagesize + $startingIndex)) -and ($itemIndex -lt [int]$paginginfo.totalCount )) {
+                            Write-Debug "$($MyInvocation.MyCommand.Name) : In Item Processing Loop: ItemIndex: $itemIndex"
+                            Write-Debug "$($MyInvocation.MyCommand.Name) : $(@($response.securityTags.securityTag)[($itemIndex - $startingIndex)].objectId)"
+
+                            $securityTags += @($response.securityTags.securityTag)[($itemIndex - $startingIndex)]
+                            $itemIndex += 1
+                        }
+                        Write-Debug "$($MyInvocation.MyCommand.Name) : Out of item processing - PagingInfo: PageSize: $($pagingInfo.PageSize), StartIndex: $($paginginfo.startIndex), TotalCount: $($paginginfo.totalcount)"
+                        if ( [int]$paginginfo.totalcount -gt $itemIndex) {
+                            Write-Debug "$($MyInvocation.MyCommand.Name) : PagingInfo: PageSize: $($pagingInfo.PageSize), StartIndex: $($paginginfo.startIndex), TotalCount: $($paginginfo.totalcount)"
+                            $startingIndex += $defaultPageSize
+                            $URI = "/api/2.0/services/securitytags/tag?pageSize=$defaultPageSize&startIndex=$startingIndex"
+
+                            $response = invoke-nsxrestmethod -method "get" -uri $URI -connection $connection
+                            $pagingInfo = $response.securityTags.pagingInfo
+                        }
+
+                    } until ( [int]$paginginfo.totalcount -le $itemIndex )
+                    Write-Debug "$($MyInvocation.MyCommand.Name) : Completed page processing: ItemIndex: $itemIndex"
+    
+                }
+            }
+            else {
+                $securityTags = $response.securityTags.securityTag
+            }
+
             if ( (Invoke-XPathQuery -QueryMethod SelectSingleNode -Node $response -Query 'descendant::securityTags/securityTag')) {
                 if  ( $PsBoundParameters.ContainsKey('Name')) {
-                    $tags = $response.securitytags.securitytag | where-object { $_.name -eq $name }
+                    $tags = $securityTags | where-object { $_.name -eq $name }
                 } else {
-                    $tags = $response.securitytags.securitytag
+                    $tags = $securityTags
                 }
 
                 if ( -not $IncludeSystem ) {

--- a/tests/integration/21.HA.Tests.ps1
+++ b/tests/integration/21.HA.Tests.ps1
@@ -72,7 +72,7 @@ Describe "Edge HA" {
         #We kill the connection to NSX Manager here.
 
         get-nsxedge $haedge1name | remove-nsxedge -confirm:$false
-        start-sleep 5
+        start-sleep 10
 
         Get-NsxLogicalSwitch $hauplinklsname | Remove-NsxLogicalSwitch -Confirm:$false
         Get-NsxLogicalSwitch $hainternallsname | Remove-NsxLogicalSwitch -Confirm:$false


### PR DESCRIPTION
Pagination support for the following cmdlets. These are required when environments have over 1024 security tags or service composer security policies

- Get-NsxSecurityPolicy
- Get-NsxSecurityTag